### PR TITLE
Fixes: PAC API, Clippy, clock tree, peripheral list

### DIFF
--- a/sifli-hal/data/sf32lb52x/peripherals.yaml
+++ b/sifli-hal/data/sf32lb52x/peripherals.yaml
@@ -4,22 +4,20 @@ hcpu:
   - name: HPSYS_RCC
     enable_reset: false
   - name: EXTDMA
-    clock: clk_peri
+    clock: hclk
   - name: HPSYS_PINMUX
     rcc_field: PINMUX1
-    clock: clk_peri
   - name: ATIM1
-    clock: clk_peri
+    clock: pclk
   - name: AUDPRC
     # TODO: clock select
     clock: clk_aud_pll
   - name: EZIP1
-    clock: clk_peri
+    clock: hclk
   - name: EPIC
-    # TODO: check if this is correct
     clock: hclk
   - name: LCDC1
-    clock: clk_peri
+    clock: hclk
   - name: I2S1
     # TODO: clock select
     clock: clk_aud_pll
@@ -27,21 +25,21 @@ hcpu:
     enable_reset: false
     clock: clk_peri
   - name: EFUSEC
-    clock: clk_peri
+    clock: pclk
   - name: AES
-    clock: clk_peri
+    clock: hclk
   - name: TRNG
-    clock: clk_peri
+    clock: pclk
   - name: MPI1
     clock: clk_mpi1
   - name: MPI2
     clock: clk_mpi2
   - name: SDMMC1
-    clock: clk_peri
+    clock: hclk
   - name: CRC1
-    clock: clk_peri
+    clock: hclk
   - name: PTC1
-    clock: clk_peri
+    clock: hclk
   - name: DMAC1
     clock: hclk
   - name: USART1
@@ -54,18 +52,18 @@ hcpu:
   - name: USART3
     clock: clk_peri
   - name: GPADC
-    clock: clk_peri
+    clock: pclk
   - name: AUDCODEC
     # TODO: clock select
     clock: clk_aud_pll
   - name: TSEN
-    clock: clk_peri
+    clock: pclk
   - name: GPTIM1
-    clock: pclk1
+    clock: pclk
   - name: BTIM1
-    clock: pclk1
+    clock: pclk
   - name: WDT1
-    clock: clk_peri
+    clock: clk_wdt
     enable_reset: false
   - name: SPI1
     clock: clk_peri
@@ -84,7 +82,7 @@ hcpu:
     clock: clk_peri
   - name: HPSYS_GPIO
     rcc_field: GPIO1
-    clock: clk_peri
+    clock: hclk
   - name: GPTIM2
     clock: clk_peri_div2
   - name: BTIM2
@@ -108,3 +106,5 @@ hcpu:
     enable_reset: false
   - name: USBC
     clock: clk_usb
+  - name: MAILBOX1
+    clock: pclk

--- a/sifli-hal/src/gpio/hpsys.rs
+++ b/sifli-hal/src/gpio/hpsys.rs
@@ -379,6 +379,10 @@ impl HpsysPin {
         self.enable_interrupt();
     }
 
+    /// Set function without setting pull-up/down.
+    /// # Safety
+    /// 
+    /// Caller must ensure fsel is valid for the pin.
     pub unsafe fn set_fsel_unchecked(&mut self, fsel: u8) {
         match self.pin {
             0..=38 => {

--- a/sifli-hal/src/gpio/mod.rs
+++ b/sifli-hal/src/gpio/mod.rs
@@ -831,11 +831,13 @@ mod eh02 {
         type Error = Infallible;
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_high())
+            self.set_high();
+            Ok(())
         }
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_low())
+            self.set_low();
+            Ok(())
         }
     }
 
@@ -853,7 +855,8 @@ mod eh02 {
         type Error = Infallible;
         #[inline]
         fn toggle(&mut self) -> Result<(), Self::Error> {
-            Ok(self.toggle())
+            self.toggle();
+            Ok(())
         }
     }
 
@@ -874,12 +877,14 @@ mod eh02 {
 
         #[inline]
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_high())
+            self.set_high();
+            Ok(())
         }
 
         #[inline]
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_low())
+            self.set_low();
+            Ok(())
         }
     }
 
@@ -897,7 +902,8 @@ mod eh02 {
         type Error = Infallible;
         #[inline]
         fn toggle(&mut self) -> Result<(), Self::Error> {
-            Ok(self.toggle())
+            self.toggle();
+            Ok(())
         }
     }
 
@@ -917,11 +923,13 @@ mod eh02 {
         type Error = Infallible;
 
         fn set_high(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_high())
+            self.set_high();
+            Ok(())
         }
 
         fn set_low(&mut self) -> Result<(), Self::Error> {
-            Ok(self.set_low())
+            self.set_low();
+            Ok(())
         }
     }
 
@@ -939,7 +947,8 @@ mod eh02 {
         type Error = Infallible;
         #[inline]
         fn toggle(&mut self) -> Result<(), Self::Error> {
-            Ok(self.toggle())
+            self.toggle();
+            Ok(())
         }
     }
 }
@@ -964,11 +973,13 @@ impl<'d> embedded_hal_1::digital::ErrorType for Output<'d> {
 
 impl<'d> embedded_hal_1::digital::OutputPin for Output<'d> {
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_high())
+        self.set_high();
+        Ok(())
     }
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_low())
+        self.set_low();
+        Ok(())
     }
 }
 
@@ -988,11 +999,13 @@ impl<'d> embedded_hal_1::digital::ErrorType for OutputOpenDrain<'d> {
 
 impl<'d> embedded_hal_1::digital::OutputPin for OutputOpenDrain<'d> {
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_high())
+        self.set_high();
+        Ok(())
     }
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_low())
+        self.set_low();
+        Ok(())
     }
 }
 
@@ -1032,11 +1045,13 @@ impl<'d> embedded_hal_1::digital::InputPin for Flex<'d> {
 
 impl<'d> embedded_hal_1::digital::OutputPin for Flex<'d> {
     fn set_high(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_high())
+        self.set_high();
+        Ok(())
     }
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
-        Ok(self.set_low())
+        self.set_low();
+        Ok(())
     }
 }
 

--- a/sifli-hal/src/gpio/mod.rs
+++ b/sifli-hal/src/gpio/mod.rs
@@ -14,7 +14,7 @@ use crate::{interrupt, peripherals, Peripheral};
 use crate::utils::BitIter64;
 
 // TODO: move this const to _generated.rs
-#[cfg(any(feature = "sf32lb52x"))]
+#[cfg(feature = "sf32lb52x")]
 pub(crate) const PA_PIN_COUNT: usize = 44;
 
 pub mod hpsys;

--- a/sifli-hal/src/lib.rs
+++ b/sifli-hal/src/lib.rs
@@ -16,9 +16,11 @@ pub mod gpio;
 pub mod timer;
 pub mod time;
 pub mod pmu;
+#[allow(clippy::all)] // modified from embassy-stm32
 pub mod usart;
 pub mod adc;
 pub mod lcdc;
+#[allow(clippy::all)] // modified from embassy-stm32
 pub mod dma;
 #[cfg(feature = "usb")]
 pub mod usb;
@@ -126,6 +128,7 @@ pub(crate) mod _generated {
     #![allow(unused_imports)]
     #![allow(non_snake_case)]
     #![allow(missing_docs)]
+    #![allow(clippy::all)]
 
     include!(concat!(env!("OUT_DIR"), "/_generated.rs"));
 }

--- a/sifli-hal/src/rcc/clock.rs
+++ b/sifli-hal/src/rcc/clock.rs
@@ -54,7 +54,7 @@ pub fn get_hclk_div() -> u8 {
     HPSYS_RCC.cfgr().read().hdiv()
 }
 
-pub fn get_pclk1_freq() -> Option<Hertz> {
+pub fn get_pclk_freq() -> Option<Hertz> {
     let hclk = get_hclk_freq()?;
     Some(hclk / (1 << HPSYS_RCC.cfgr().read().pdiv1()) as u32)
 }
@@ -148,7 +148,7 @@ pub fn test_print_clocks() {
     let clocks = [
         ("clk_sys", get_clk_sys_freq()),
         ("hclk", get_hclk_freq()),
-        ("pclk1", get_pclk1_freq()),
+        ("pclk", get_pclk_freq()),
         ("pclk2", get_pclk2_freq()),
         ("clk_peri", get_clk_peri_freq()),
         ("clk_peri_div2", get_clk_peri_div2_freq()),

--- a/sifli-hal/src/rcc/clock_configure.rs
+++ b/sifli-hal/src/rcc/clock_configure.rs
@@ -139,7 +139,7 @@ impl Config {
 
     /// Apply the RCC clock configuration to the hardware registers
     /// 
-    /// Safety
+    /// # Safety
     /// This function is typically called by sifli_hal::init() (configured 
     /// in sifli_hal::Config.rcc), but can also be called independently as 
     /// long as it does not interfere with the clocks of already initialized 

--- a/sifli-hal/src/utils.rs
+++ b/sifli-hal/src/utils.rs
@@ -8,9 +8,6 @@ pub(crate)struct BitFlags8 {
 }
 
 impl BitFlags8 {
-    pub const ZERO: Self = Self {
-        flags: AtomicU8::new(0),
-    };
     /// Creates new bit flags with an initial value.
     pub(crate)fn new(initial_value: u8) -> Self {
         Self {
@@ -58,9 +55,6 @@ pub(crate)struct BitFlags32 {
 }
 
 impl BitFlags32 {
-    pub const ZERO: Self = Self {
-        flags: AtomicU32::new(0),
-    };
     /// Creates new bit flags with an initial value.
     pub(crate)fn new(initial_value: u32) -> Self {
         Self {
@@ -108,10 +102,6 @@ pub(crate)struct BitFlags64 {
 }
 
 impl BitFlags64 {
-    pub const ZERO: Self = Self {
-        flags: AtomicU64::new(0),
-    };
-
     /// Creates new bit flags with an initial value.
     pub(crate)fn new(initial_value: u64) -> Self {
         Self {


### PR DESCRIPTION
Adapt to PAC API changes introduced by the chiptool update.
Fix Clippy warnings, update the clock tree, and refresh the peripheral list (added mailbox).