### PR TITLE
Use Singleton pattern for LCPU ownership

### DIFF
--- a/examples/sf32lb52x/src/bin/ble_advertise.rs
+++ b/examples/sf32lb52x/src/bin/ble_advertise.rs
@@ -51,19 +51,24 @@ async fn main(_spawner: embassy_executor::Spawner) {
     info!("=== BLE Advertise Example ===");
 
     // 1. BLE startup (IPC + LCPU power-on + HCI transport)
-    let transport =
-        match IpcHciTransport::ble_init(p.MAILBOX1_CH1, Irqs, p.DMAC2_CH8, &LcpuConfig::default())
-            .await
-        {
-            Ok(t) => t,
-            Err(e) => {
-                error!("BLE init failed: {:?}", e);
-                cortex_m::asm::bkpt();
-                loop {
-                    Timer::after_secs(1).await;
-                }
+    let transport = match IpcHciTransport::ble_init(
+        p.LCPU,
+        p.MAILBOX1_CH1,
+        p.DMAC2_CH8,
+        Irqs,
+        &LcpuConfig::default(),
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            error!("BLE init failed: {:?}", e);
+            cortex_m::asm::bkpt();
+            loop {
+                Timer::after_secs(1).await;
             }
-        };
+        }
+    };
     info!("LCPU BLE is ready");
 
     // 2. Create HCI controller

--- a/sifli-hal/data/sf32lb52x/peripherals.yaml
+++ b/sifli-hal/data/sf32lb52x/peripherals.yaml
@@ -112,6 +112,8 @@ hcpu:
     clock: pclk
   - name: MAILBOX2
     enable_reset: false
+  - name: LCPU
+    enable_reset: false
 
 # Note: Some LCPU peripherals are not yet defined in PAC (sifli-pac).
 # Missing from PAC: LPSYS_PINMUX, USART4, USART5, LPSYS_SECU, PTC2, BTIM3, BTIM4,

--- a/sifli-hal/src/lcpu/mod.rs
+++ b/sifli-hal/src/lcpu/mod.rs
@@ -206,7 +206,9 @@ pub enum CoreId {
 //=============================================================================
 
 /// LCPU driver (blocking).
-pub struct Lcpu;
+pub struct Lcpu {
+    _lcpu: crate::PeripheralRef<'static, crate::peripherals::LCPU>,
+}
 
 impl fmt::Debug for Lcpu {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -216,8 +218,10 @@ impl fmt::Debug for Lcpu {
 
 impl Lcpu {
     /// Create a new blocking LCPU driver.
-    pub fn new() -> Self {
-        Self
+    pub fn new(lcpu: impl Peripheral<P = crate::peripherals::LCPU> + 'static) -> Self {
+        Self {
+            _lcpu: lcpu.into_ref(),
+        }
     }
 }
 


### PR DESCRIPTION
ince the HCPU firmware manages the LCPU as a peripheral, I have updated `IpcHciTransport::ble_init` and  `Lcpu::new() ` to require the LCPU singleton. This ensures unique ownership of the peripheral. 

API Changes:
```rust
// Before
let transport = IpcHciTransport::ble_init(
    p.MAILBOX1_CH1, 
    Irqs,
    p.DMAC2_CH8,
    &LcpuConfig::default()
);

// After
let transport = IpcHciTransport::ble_init(
    p.LCPU, // Now required
    p.MAILBOX1_CH1,
    p.DMAC2_CH8,
    Irqs,
    &LcpuConfig::default(),
);
```