### PR TITLE
feat(hal/i2c): add I2C driver with blocking and async modes

### DIFF
--- a/examples/sf32lb52x/build.rs
+++ b/examples/sf32lb52x/build.rs
@@ -1,10 +1,20 @@
 fn main() {
+    // Put `memory.x` in our output directory and ensure it's on the linker search path.
+    let out = std::env::var("OUT_DIR").unwrap();
+    let out_dir = std::path::Path::new(&out);
+    std::fs::copy("memory.x", out_dir.join("memory.x")).unwrap();
+    std::fs::copy("psram.x", out_dir.join("psram.x")).unwrap();
+    println!("cargo:rustc-link-search={out}");
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=psram.x");
+
     // `--nmagic` is required if memory section addresses are not aligned to 0x10000,
     // for example the FLASH and RAM sections in your `memory.x`.
     // See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
     println!("cargo:rustc-link-arg=--nmagic");
 
     println!("cargo:rustc-link-arg=-Tlink.x");
+    println!("cargo:rustc-link-arg=-Tpsram.x");
 
     println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/examples/sf32lb52x/psram.x
+++ b/examples/sf32lb52x/psram.x
@@ -1,0 +1,7 @@
+SECTIONS
+{
+  .psram_bss (NOLOAD) :
+  {
+    *(.psram_bss .psram_bss.*);
+  } > PSRAM
+}

--- a/examples/sf32lb52x/src/bin/i2c_9axis.rs
+++ b/examples/sf32lb52x/src/bin/i2c_9axis.rs
@@ -1,0 +1,230 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use embedded_io::Write;
+use sifli_hal::i2c::{self, I2c};
+use sifli_hal::usart::{Config as UartConfig, Uart};
+use {defmt_rtt as _, panic_probe as _};
+
+// 9-axis sensor example: LSM6DS3TR-C (6-axis IMU) + MMC5603NJ (3-axis magnetometer)
+//
+// Hardware:
+//   I2C3: PA40 (SCL), PA39 (SDA)
+//   PA38, PA30: Sensor board power enables
+//   PA18/PA19: UART1 TX/RX (debug, 1Mbps)
+//
+// Devices:
+//   LSM6DS3TR-C @ 0x6A  - Accelerometer + Gyroscope
+//   MMC5603NJ   @ 0x30  - Magnetometer
+
+// --- LSM6DS3TR-C registers ---
+const LSM6_ADDR: u8 = 0x6A;
+const LSM6_WHO_AM_I: u8 = 0x0F;
+const LSM6_CTRL1_XL: u8 = 0x10; // Accelerometer control
+const LSM6_CTRL2_G: u8 = 0x11; // Gyroscope control
+const LSM6_CTRL3_C: u8 = 0x12; // Common control (BDU, IF_INC)
+const LSM6_STATUS: u8 = 0x1E;
+const LSM6_OUT_GYRO: u8 = 0x22; // OUTX_L_G, 6 bytes (gyro XYZ)
+const LSM6_OUT_ACCEL: u8 = 0x28; // OUTX_L_XL, 6 bytes (accel XYZ)
+
+// --- MMC5603NJ registers ---
+const MMC_ADDR: u8 = 0x30;
+const MMC_PRODUCT_ID: u8 = 0x39;
+const MMC_XOUT0: u8 = 0x00; // X[19:12]
+const MMC_STATUS: u8 = 0x18; // Bit 6: Meas_M_Done
+const MMC_CTRL0: u8 = 0x1B;
+#[allow(dead_code)]
+const MMC_CTRL2: u8 = 0x1D;
+
+/// Read a single register
+fn read_reg(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>, addr: u8, reg: u8) -> Result<u8, i2c::Error> {
+    let mut buf = [0u8; 1];
+    i2c.blocking_write_read(addr, &[reg], &mut buf)?;
+    Ok(buf[0])
+}
+
+/// Write a single register
+fn write_reg(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>, addr: u8, reg: u8, val: u8) -> Result<(), i2c::Error> {
+    i2c.blocking_write(addr, &[reg, val])
+}
+
+/// Parse 16-bit signed value from two bytes (little-endian)
+fn i16_from_le(buf: &[u8], offset: usize) -> i16 {
+    i16::from_le_bytes([buf[offset], buf[offset + 1]])
+}
+
+/// Initialize LSM6DS3TR-C: 104Hz ODR, ±4g accel, ±500dps gyro
+fn init_lsm6(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>, usart: &mut impl Write) -> bool {
+    let who = read_reg(i2c, LSM6_ADDR, LSM6_WHO_AM_I);
+    match who {
+        Ok(id) => {
+            let _ = writeln!(usart, "LSM6DS3TR-C WHO_AM_I: 0x{:02X}", id);
+            if id != 0x6A {
+                let _ = writeln!(usart, "  WARNING: expected 0x6A");
+            }
+        }
+        Err(e) => {
+            let _ = writeln!(usart, "LSM6DS3TR-C not found: {:?}", defmt::Debug2Format(&e));
+            return false;
+        }
+    }
+
+    // CTRL3_C: BDU=1 (block data update), IF_INC=1 (auto-increment address)
+    let _ = write_reg(i2c, LSM6_ADDR, LSM6_CTRL3_C, 0x44);
+
+    // CTRL1_XL: ODR=104Hz (0100), FS=±4g (10), BW=400Hz (00)
+    // 0100_10_00 = 0x48
+    let _ = write_reg(i2c, LSM6_ADDR, LSM6_CTRL1_XL, 0x48);
+
+    // CTRL2_G: ODR=104Hz (0100), FS=±500dps (01), FS_125=0
+    // 0100_01_0_0 = 0x44
+    let _ = write_reg(i2c, LSM6_ADDR, LSM6_CTRL2_G, 0x44);
+
+    let _ = writeln!(usart, "LSM6DS3TR-C initialized (104Hz, ±4g, ±500dps)");
+    true
+}
+
+/// Read LSM6DS3TR-C accelerometer and gyroscope data
+fn read_lsm6(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>) -> Option<([i16; 3], [i16; 3])> {
+    // Check data ready
+    let status = read_reg(i2c, LSM6_ADDR, LSM6_STATUS).ok()?;
+    if status & 0x03 == 0 {
+        return None; // No new data
+    }
+
+    // Read gyroscope (6 bytes from 0x22, auto-increment)
+    let mut gyro_buf = [0u8; 6];
+    i2c.blocking_write_read(LSM6_ADDR, &[LSM6_OUT_GYRO], &mut gyro_buf).ok()?;
+    let gx = i16_from_le(&gyro_buf, 0);
+    let gy = i16_from_le(&gyro_buf, 2);
+    let gz = i16_from_le(&gyro_buf, 4);
+
+    // Read accelerometer (6 bytes from 0x28, auto-increment)
+    let mut accel_buf = [0u8; 6];
+    i2c.blocking_write_read(LSM6_ADDR, &[LSM6_OUT_ACCEL], &mut accel_buf).ok()?;
+    let ax = i16_from_le(&accel_buf, 0);
+    let ay = i16_from_le(&accel_buf, 2);
+    let az = i16_from_le(&accel_buf, 4);
+
+    Some(([ax, ay, az], [gx, gy, gz]))
+}
+
+/// Initialize MMC5603NJ
+fn init_mmc5603(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>, usart: &mut impl Write) -> bool {
+    let who = read_reg(i2c, MMC_ADDR, MMC_PRODUCT_ID);
+    match who {
+        Ok(id) => {
+            let _ = writeln!(usart, "MMC5603NJ Product ID: 0x{:02X}", id);
+            if id != 0x10 {
+                let _ = writeln!(usart, "  WARNING: expected 0x10");
+            }
+        }
+        Err(e) => {
+            let _ = writeln!(usart, "MMC5603NJ not found: {:?}", defmt::Debug2Format(&e));
+            return false;
+        }
+    }
+
+    // Do a SET operation first for proper sensor offset calibration (CTRL0 bit 3)
+    let _ = write_reg(i2c, MMC_ADDR, MMC_CTRL0, 0x08);
+
+    let _ = writeln!(usart, "MMC5603NJ initialized (single-shot mode)");
+    true
+}
+
+/// Read MMC5603NJ magnetometer data using single-shot measurement.
+/// Triggers a measurement, waits, then reads result.
+fn read_mmc5603(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>) -> Option<[i32; 3]> {
+    // Trigger single measurement: CTRL0 TM_M bit (bit 0)
+    write_reg(i2c, MMC_ADDR, MMC_CTRL0, 0x01).ok()?;
+
+    // Wait for measurement (~8ms typical for default BW)
+    embassy_time::block_for(embassy_time::Duration::from_millis(10));
+
+    // Check status (bit 6 = Meas_M_Done)
+    let status = read_reg(i2c, MMC_ADDR, MMC_STATUS).ok()?;
+    if status & 0x40 == 0 {
+        return None;
+    }
+
+    // Read 6 bytes from 0x00 (XOUT0..ZOUT1), 16-bit mode
+    let mut buf = [0u8; 6];
+    i2c.blocking_write_read(MMC_ADDR, &[MMC_XOUT0], &mut buf).ok()?;
+
+    // Data is unsigned 16-bit, offset binary (midpoint = 32768 = 0 Gauss)
+    let mx = ((buf[0] as u16) << 8 | buf[1] as u16) as i32 - 32768;
+    let my = ((buf[2] as u16) << 8 | buf[3] as u16) as i32 - 32768;
+    let mz = ((buf[4] as u16) << 8 | buf[5] as u16) as i32 - 32768;
+
+    Some([mx, my, mz])
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = sifli_hal::init(Default::default());
+
+    // UART debug
+    let mut uart_config = UartConfig::default();
+    uart_config.baudrate = 1000000;
+    let mut usart = Uart::new_blocking(p.USART1, p.PA18, p.PA19, uart_config).unwrap();
+
+    let _ = writeln!(usart, "\r\n=== 9-Axis Sensor Example ===");
+    let _ = writeln!(usart, "LSM6DS3TR-C (Accel+Gyro) + MMC5603NJ (Mag)\r\n");
+
+    // Enable sensor board power
+    sifli_hal::pac::PMUC.peri_ldo().modify(|w| {
+        w.set_en_vdd33_ldo3(true);
+        w.set_vdd33_ldo3_pd(false);
+    });
+    {
+        let en1 = sifli_hal::gpio::Output::new(&mut p.PA38, sifli_hal::gpio::Level::High);
+        let en2 = sifli_hal::gpio::Output::new(&mut p.PA30, sifli_hal::gpio::Level::High);
+        core::mem::forget(en1);
+        core::mem::forget(en2);
+    }
+    Timer::after_millis(100).await;
+
+    // Create blocking I2C
+    let mut i2c = I2c::new_blocking(p.I2C3, p.PA40, p.PA39, i2c::Config::default());
+
+    // Initialize sensors
+    let has_imu = init_lsm6(&mut i2c, &mut usart);
+    let has_mag = init_mmc5603(&mut i2c, &mut usart);
+
+    if !has_imu && !has_mag {
+        let _ = writeln!(usart, "\nNo sensors found!");
+        loop { Timer::after_secs(1).await; }
+    }
+
+    Timer::after_millis(100).await; // Wait for first measurements
+
+    let _ = writeln!(usart, "\nReading sensor data...\r\n");
+
+    loop {
+        if has_imu {
+            if let Some((accel, gyro)) = read_lsm6(&mut i2c) {
+                // ±4g: sensitivity = 0.122 mg/LSB → mg = raw * 122 / 1000
+                // ±500dps: sensitivity = 17.50 mdps/LSB
+                let _ = writeln!(usart,
+                    "Accel: X={:6} Y={:6} Z={:6}  Gyro: X={:6} Y={:6} Z={:6}",
+                    accel[0], accel[1], accel[2],
+                    gyro[0], gyro[1], gyro[2],
+                );
+            }
+        }
+
+        if has_mag {
+            if let Some(mag) = read_mmc5603(&mut i2c) {
+                // 16-bit mode: 1 LSB ≈ 0.0625 mGauss (range ±30 Gauss)
+                let _ = writeln!(usart,
+                    "Mag:   X={:6} Y={:6} Z={:6}",
+                    mag[0], mag[1], mag[2],
+                );
+            }
+        }
+
+        Timer::after_millis(100).await;
+    }
+}

--- a/examples/sf32lb52x/src/bin/i2c_9axis_async.rs
+++ b/examples/sf32lb52x/src/bin/i2c_9axis_async.rs
@@ -1,0 +1,244 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use embedded_io::Write;
+use sifli_hal::i2c::{self, I2c};
+use sifli_hal::usart::{Config as UartConfig, Uart};
+use sifli_hal::{bind_interrupts, peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    I2C3 => i2c::InterruptHandler<peripherals::I2C3>;
+});
+
+// Async 9-axis sensor example: LSM6DS3TR-C + MMC5603NJ
+// Verifies both write_read() and transaction() API with repeated START.
+//
+// Hardware:
+//   I2C3: PA40 (SCL), PA39 (SDA)
+//   PA38, PA30: Sensor board power enables
+//   PA18/PA19: UART1 TX/RX (debug, 1Mbps)
+
+const LSM6_ADDR: u8 = 0x6A;
+const LSM6_WHO_AM_I: u8 = 0x0F;
+const LSM6_CTRL1_XL: u8 = 0x10;
+const LSM6_CTRL2_G: u8 = 0x11;
+const LSM6_CTRL3_C: u8 = 0x12;
+const LSM6_STATUS: u8 = 0x1E;
+const LSM6_OUT_GYRO: u8 = 0x22;
+const LSM6_OUT_ACCEL: u8 = 0x28;
+
+const MMC_ADDR: u8 = 0x30;
+const MMC_PRODUCT_ID: u8 = 0x39;
+const MMC_XOUT0: u8 = 0x00;
+const MMC_STATUS: u8 = 0x18;
+const MMC_CTRL0: u8 = 0x1B;
+
+/// Parse 16-bit signed value from two bytes (little-endian)
+fn i16_from_le(buf: &[u8], offset: usize) -> i16 {
+    i16::from_le_bytes([buf[offset], buf[offset + 1]])
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = sifli_hal::init(Default::default());
+
+    let mut uart_config = UartConfig::default();
+    uart_config.baudrate = 1000000;
+    let mut usart = Uart::new_blocking(p.USART1, p.PA18, p.PA19, uart_config).unwrap();
+
+    let _ = writeln!(usart, "\r\n=== Async 9-Axis Sensor Example ===");
+    let _ = writeln!(usart, "Tests write_read() and transaction() API\r\n");
+
+    // Enable sensor board power
+    sifli_hal::pac::PMUC.peri_ldo().modify(|w| {
+        w.set_en_vdd33_ldo3(true);
+        w.set_vdd33_ldo3_pd(false);
+    });
+    {
+        let en1 = sifli_hal::gpio::Output::new(&mut p.PA38, sifli_hal::gpio::Level::High);
+        let en2 = sifli_hal::gpio::Output::new(&mut p.PA30, sifli_hal::gpio::Level::High);
+        core::mem::forget(en1);
+        core::mem::forget(en2);
+    }
+    Timer::after_millis(100).await;
+
+    let mut i2c = I2c::new(p.I2C3, p.PA40, p.PA39, Irqs, i2c::Config::default());
+
+    // --- Verify transaction() API with WHO_AM_I reads ---
+    let _ = writeln!(usart, "--- transaction() API test ---");
+
+    // Test 1: transaction([Write, Read]) should use repeated START
+    {
+        use embedded_hal_async::i2c::I2c as _;
+        let mut buf = [0u8; 1];
+        match i2c
+            .transaction(
+                MMC_ADDR,
+                &mut [
+                    embedded_hal_async::i2c::Operation::Write(&[MMC_PRODUCT_ID]),
+                    embedded_hal_async::i2c::Operation::Read(&mut buf),
+                ],
+            )
+            .await
+        {
+            Ok(_) => {
+                let _ = writeln!(
+                    usart,
+                    "transaction() MMC5603 WHO_AM_I: 0x{:02X} (expect 0x10) {}",
+                    buf[0],
+                    if buf[0] == 0x10 { "OK" } else { "MISMATCH" }
+                );
+            }
+            Err(e) => {
+                let _ = writeln!(usart, "transaction() MMC5603 error: {:?}", defmt::Debug2Format(&e));
+            }
+        }
+    }
+
+    // Test 2: Same read using write_read() for comparison
+    {
+        let mut buf = [0u8; 1];
+        match i2c.write_read(MMC_ADDR, &[MMC_PRODUCT_ID], &mut buf).await {
+            Ok(_) => {
+                let _ = writeln!(
+                    usart,
+                    "write_read()  MMC5603 WHO_AM_I: 0x{:02X} (expect 0x10) {}",
+                    buf[0],
+                    if buf[0] == 0x10 { "OK" } else { "MISMATCH" }
+                );
+            }
+            Err(e) => {
+                let _ = writeln!(usart, "write_read()  MMC5603 error: {:?}", defmt::Debug2Format(&e));
+            }
+        }
+    }
+
+    // Test 3: LSM6DS3TR-C WHO_AM_I via transaction()
+    {
+        use embedded_hal_async::i2c::I2c as _;
+        let mut buf = [0u8; 1];
+        match i2c
+            .transaction(
+                LSM6_ADDR,
+                &mut [
+                    embedded_hal_async::i2c::Operation::Write(&[LSM6_WHO_AM_I]),
+                    embedded_hal_async::i2c::Operation::Read(&mut buf),
+                ],
+            )
+            .await
+        {
+            Ok(_) => {
+                let _ = writeln!(
+                    usart,
+                    "transaction() LSM6DS3 WHO_AM_I: 0x{:02X} (expect 0x6A) {}",
+                    buf[0],
+                    if buf[0] == 0x6A { "OK" } else { "MISMATCH" }
+                );
+            }
+            Err(e) => {
+                let _ = writeln!(usart, "transaction() LSM6DS3 error: {:?}", defmt::Debug2Format(&e));
+            }
+        }
+    }
+
+    // --- Initialize sensors ---
+    let _ = writeln!(usart, "\n--- Sensor init ---");
+
+    // LSM6DS3TR-C init
+    let has_imu = match init_sensor_async(&mut i2c, &mut usart).await {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(usart, "IMU init error: {:?}", defmt::Debug2Format(&e));
+            false
+        }
+    };
+
+    // MMC5603NJ SET operation
+    if i2c.write(MMC_ADDR, &[MMC_CTRL0, 0x08]).await.is_ok() {
+        let _ = writeln!(usart, "MMC5603NJ SET done");
+    }
+
+    if !has_imu {
+        let _ = writeln!(usart, "No IMU, entering mag-only loop");
+    }
+
+    Timer::after_millis(100).await;
+    let _ = writeln!(usart, "\n--- Sensor data loop (async) ---\r\n");
+
+    loop {
+        if has_imu {
+            // Read status + accel + gyro data
+            let mut status = [0u8; 1];
+            if i2c.write_read(LSM6_ADDR, &[LSM6_STATUS], &mut status).await.is_ok()
+                && (status[0] & 0x03) != 0
+            {
+                let mut gyro_buf = [0u8; 6];
+                let mut accel_buf = [0u8; 6];
+                // Read gyro and accel separately using async
+                if i2c
+                    .write_read(LSM6_ADDR, &[LSM6_OUT_GYRO], &mut gyro_buf)
+                    .await
+                    .is_ok()
+                    && i2c
+                        .write_read(LSM6_ADDR, &[LSM6_OUT_ACCEL], &mut accel_buf)
+                        .await
+                        .is_ok()
+                {
+                    let ax = i16_from_le(&accel_buf, 0);
+                    let ay = i16_from_le(&accel_buf, 2);
+                    let az = i16_from_le(&accel_buf, 4);
+                    let gx = i16_from_le(&gyro_buf, 0);
+                    let gy = i16_from_le(&gyro_buf, 2);
+                    let gz = i16_from_le(&gyro_buf, 4);
+                    let _ = writeln!(
+                        usart,
+                        "A:{:6},{:6},{:6} G:{:6},{:6},{:6}",
+                        ax, ay, az, gx, gy, gz,
+                    );
+                }
+            }
+        }
+
+        // MMC5603NJ single-shot read
+        if i2c.write(MMC_ADDR, &[MMC_CTRL0, 0x01]).await.is_ok() {
+            Timer::after_millis(10).await;
+            let mut status = [0u8; 1];
+            if i2c.write_read(MMC_ADDR, &[MMC_STATUS], &mut status).await.is_ok()
+                && (status[0] & 0x40) != 0
+            {
+                let mut buf = [0u8; 6];
+                if i2c.write_read(MMC_ADDR, &[MMC_XOUT0], &mut buf).await.is_ok() {
+                    let mx = ((buf[0] as u16) << 8 | buf[1] as u16) as i32 - 32768;
+                    let my = ((buf[2] as u16) << 8 | buf[3] as u16) as i32 - 32768;
+                    let mz = ((buf[4] as u16) << 8 | buf[5] as u16) as i32 - 32768;
+                    let _ = writeln!(usart, "M:{:6},{:6},{:6}", mx, my, mz);
+                }
+            }
+        }
+
+        Timer::after_millis(100).await;
+    }
+}
+
+async fn init_sensor_async(
+    i2c: &mut I2c<'_, impl i2c::Instance, sifli_hal::mode::Async>,
+    usart: &mut impl Write,
+) -> Result<bool, i2c::Error> {
+    let mut buf = [0u8; 1];
+    i2c.write_read(LSM6_ADDR, &[LSM6_WHO_AM_I], &mut buf).await?;
+    let _ = writeln!(usart, "LSM6DS3TR-C WHO_AM_I: 0x{:02X}", buf[0]);
+    if buf[0] != 0x6A {
+        let _ = writeln!(usart, "  WARNING: expected 0x6A");
+    }
+    // CTRL3_C: BDU=1, IF_INC=1
+    i2c.write(LSM6_ADDR, &[LSM6_CTRL3_C, 0x44]).await?;
+    // CTRL1_XL: 104Hz, ±4g
+    i2c.write(LSM6_ADDR, &[LSM6_CTRL1_XL, 0x48]).await?;
+    // CTRL2_G: 104Hz, ±500dps
+    i2c.write(LSM6_ADDR, &[LSM6_CTRL2_G, 0x44]).await?;
+    let _ = writeln!(usart, "LSM6DS3TR-C initialized (104Hz, +/-4g, +/-500dps)");
+    Ok(true)
+}

--- a/examples/sf32lb52x/src/bin/i2c_async.rs
+++ b/examples/sf32lb52x/src/bin/i2c_async.rs
@@ -1,0 +1,117 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use embedded_io::Write;
+use sifli_hal::i2c::{self, I2c};
+use sifli_hal::usart::{Config as UartConfig, Uart};
+use sifli_hal::{bind_interrupts, peripherals};
+use {defmt_rtt as _, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    I2C3 => i2c::InterruptHandler<peripherals::I2C3>;
+});
+
+// Async I2C example - read sensors on I2C3 bus
+//
+// Hardware:
+//   PA40 (SCL) -> I2C bus SCL (with pull-up)
+//   PA39 (SDA) -> I2C bus SDA (with pull-up)
+//   PA38       -> Sensor board power enable 1
+//   PA30       -> Sensor board power enable 2
+//   PA18/PA19  -> UART1 TX/RX (debug)
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = sifli_hal::init(Default::default());
+
+    // UART debug
+    let mut uart_config = UartConfig::default();
+    uart_config.baudrate = 1000000;
+    let mut usart = Uart::new_blocking(p.USART1, p.PA18, p.PA19, uart_config).unwrap();
+
+    let _ = writeln!(usart, "\r\n=== I2C Async Example ===");
+
+    // Enable sensor board power
+    // LDO3 for general peripheral power
+    sifli_hal::pac::PMUC.peri_ldo().modify(|w| {
+        w.set_en_vdd33_ldo3(true);
+        w.set_vdd33_ldo3_pd(false);
+    });
+    // PA38 and PA30: sensor board power enables
+    {
+        let en1 = sifli_hal::gpio::Output::new(&mut p.PA38, sifli_hal::gpio::Level::High);
+        let en2 = sifli_hal::gpio::Output::new(&mut p.PA30, sifli_hal::gpio::Level::High);
+        core::mem::forget(en1);
+        core::mem::forget(en2);
+    }
+    Timer::after_millis(100).await;
+
+    let _ = writeln!(usart, "Sensor power enabled");
+
+    // Create async I2C
+    let mut i2c = I2c::new(p.I2C3, p.PA40, p.PA39, Irqs, i2c::Config::default());
+
+    let _ = writeln!(usart, "I2C3 async initialized");
+
+    // Quick scan of common sensor addresses
+    let _ = writeln!(usart, "Scanning common addresses...");
+    let probe_addrs: &[u8] = &[0x0E, 0x19, 0x23, 0x29, 0x30, 0x6A, 0x6B];
+    for &addr in probe_addrs {
+        match i2c.write(addr, &[]).await {
+            Ok(_) => {
+                let _ = writeln!(usart, "  0x{:02X}: ACK", addr);
+            }
+            Err(_) => {
+                let _ = writeln!(usart, "  0x{:02X}: NACK", addr);
+            }
+        }
+    }
+
+    // Try reading WHO_AM_I from known sensors
+    let mut buf = [0u8; 1];
+
+    // MMC5603NJ magnetometer (0x30, WHO_AM_I register 0x39, expect 0x10)
+    match i2c.write_read(0x30, &[0x39], &mut buf).await {
+        Ok(_) => {
+            let _ = writeln!(usart, "MMC5603 (0x30) WHO_AM_I: 0x{:02X} (expect 0x10)", buf[0]);
+        }
+        Err(e) => {
+            let _ = writeln!(usart, "MMC5603 (0x30) error: {:?}", defmt::Debug2Format(&e));
+        }
+    }
+
+    // LSM6DSx IMU (0x6A or 0x6B, WHO_AM_I register 0x0F)
+    for addr in [0x6Au8, 0x6B] {
+        match i2c.write_read(addr, &[0x0F], &mut buf).await {
+            Ok(_) => {
+                let _ = writeln!(usart, "LSM6DSx (0x{:02X}) WHO_AM_I: 0x{:02X}", addr, buf[0]);
+            }
+            Err(_) => {}
+        }
+    }
+
+    // QMC5883L / QMI8658 etc at 0x29
+    match i2c.write_read(0x29, &[0x00], &mut buf).await {
+        Ok(_) => {
+            let _ = writeln!(usart, "Device (0x29) reg0x00: 0x{:02X}", buf[0]);
+        }
+        Err(_) => {}
+    }
+
+    let _ = writeln!(usart, "\nEntering periodic read loop...");
+
+    loop {
+        // Try reading from any device that responded
+        match i2c.write_read(0x30, &[0x39], &mut buf).await {
+            Ok(_) => {
+                let _ = writeln!(usart, "WHO_AM_I: 0x{:02X}", buf[0]);
+            }
+            Err(_) => {
+                let _ = writeln!(usart, "read failed");
+            }
+        }
+        Timer::after_secs(2).await;
+    }
+}

--- a/examples/sf32lb52x/src/bin/i2c_blocking.rs
+++ b/examples/sf32lb52x/src/bin/i2c_blocking.rs
@@ -1,0 +1,133 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use embedded_io::Write;
+use sifli_hal::i2c::{self, I2c};
+use sifli_hal::usart::{Config as UartConfig, Uart};
+use {defmt_rtt as _, panic_probe as _};
+
+// Blocking I2C example - scan and read sensors
+//
+// Hardware:
+//   PA40 (SCL) -> I2C bus SCL (with pull-up)
+//   PA39 (SDA) -> I2C bus SDA (with pull-up)
+//   PA38       -> Sensor board power enable 1
+//   PA30       -> Sensor board power enable 2
+//   PA18/PA19  -> UART1 TX/RX (debug)
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = sifli_hal::init(Default::default());
+
+    // UART debug
+    let mut uart_config = UartConfig::default();
+    uart_config.baudrate = 1000000;
+    let mut usart = Uart::new_blocking(p.USART1, p.PA18, p.PA19, uart_config).unwrap();
+
+    let _ = writeln!(usart, "\r\n=== I2C Blocking Example ===");
+
+    // Enable sensor board power
+    sifli_hal::pac::PMUC.peri_ldo().modify(|w| {
+        w.set_en_vdd33_ldo3(true);
+        w.set_vdd33_ldo3_pd(false);
+    });
+    {
+        let en1 = sifli_hal::gpio::Output::new(&mut p.PA38, sifli_hal::gpio::Level::High);
+        let en2 = sifli_hal::gpio::Output::new(&mut p.PA30, sifli_hal::gpio::Level::High);
+        core::mem::forget(en1);
+        core::mem::forget(en2);
+    }
+    Timer::after_millis(100).await;
+    let _ = writeln!(usart, "Sensor power enabled");
+
+    // Create blocking I2C
+    let mut i2c = I2c::new_blocking(p.I2C3, p.PA40, p.PA39, i2c::Config::default());
+    let _ = writeln!(usart, "I2C3 blocking initialized");
+
+    // Dump registers
+    {
+        let i2c3 = sifli_hal::pac::I2C3;
+        let cr = i2c3.cr().read();
+        let bmr = i2c3.bmr().read();
+        let lcr = i2c3.lcr().read();
+        let wcr = i2c3.wcr().read();
+        let _ = writeln!(usart, "CR: 0x{:08X} MODE={}, SCLE={}, IUE={}", cr.0, cr.mode(), cr.scle(), cr.iue());
+        let _ = writeln!(usart, "BMR: SCL={}, SDA={}", bmr.scl(), bmr.sda());
+        let _ = writeln!(usart, "LCR: FLV={}, SLV={}", lcr.flv(), lcr.slv());
+        let _ = writeln!(usart, "WCR: CNT={}", wcr.cnt());
+    }
+
+    // Test single address first - probe 0x08 (likely NACK) to see timing
+    {
+        let _ = write!(usart, "Probe 0x08: ");
+        let t0 = embassy_time::Instant::now();
+        let result = i2c.blocking_write(0x08, &[]);
+        let dt = t0.elapsed().as_millis();
+        let _ = writeln!(usart, "{:?} ({}ms)", defmt::Debug2Format(&result), dt);
+
+        // Check SR after probe
+        let sr = sifli_hal::pac::I2C3.sr().read();
+        let _ = writeln!(usart, "SR after: 0x{:08X} TE={} NACK={} BED={} UB={}",
+            sr.0, sr.te(), sr.nack(), sr.bed(), sr.ub());
+    }
+
+    // Test a known device address (0x29 was found in previous scan)
+    {
+        let _ = write!(usart, "Probe 0x29: ");
+        let t0 = embassy_time::Instant::now();
+        let result = i2c.blocking_write(0x29, &[]);
+        let dt = t0.elapsed().as_millis();
+        let _ = writeln!(usart, "{:?} ({}ms)", defmt::Debug2Format(&result), dt);
+
+        let sr = sifli_hal::pac::I2C3.sr().read();
+        let _ = writeln!(usart, "SR after: 0x{:08X} TE={} NACK={} BED={} UB={}",
+            sr.0, sr.te(), sr.nack(), sr.bed(), sr.ub());
+    }
+
+    // Test 0x30 (MMC5603)
+    {
+        let _ = write!(usart, "Probe 0x30: ");
+        let t0 = embassy_time::Instant::now();
+        let result = i2c.blocking_write(0x30, &[]);
+        let dt = t0.elapsed().as_millis();
+        let _ = writeln!(usart, "{:?} ({}ms)", defmt::Debug2Format(&result), dt);
+
+        let sr = sifli_hal::pac::I2C3.sr().read();
+        let _ = writeln!(usart, "SR after: 0x{:08X} TE={} NACK={} BED={} UB={}",
+            sr.0, sr.te(), sr.nack(), sr.bed(), sr.ub());
+    }
+
+    // If any device responded, try reading registers
+    let _ = writeln!(usart, "\nTrying write_read on 0x29...");
+    {
+        let mut buf = [0u8; 1];
+        match i2c.blocking_write_read(0x29, &[0x00], &mut buf) {
+            Ok(_) => {
+                let _ = writeln!(usart, "  0x29 reg[0x00] = 0x{:02X}", buf[0]);
+            }
+            Err(e) => {
+                let _ = writeln!(usart, "  0x29 reg[0x00] err: {:?}", defmt::Debug2Format(&e));
+            }
+        }
+    }
+
+    let _ = writeln!(usart, "Trying write_read on 0x30...");
+    {
+        let mut buf = [0u8; 1];
+        match i2c.blocking_write_read(0x30, &[0x39], &mut buf) {
+            Ok(_) => {
+                let _ = writeln!(usart, "  0x30 reg[0x39] = 0x{:02X}", buf[0]);
+            }
+            Err(e) => {
+                let _ = writeln!(usart, "  0x30 reg[0x39] err: {:?}", defmt::Debug2Format(&e));
+            }
+        }
+    }
+
+    let _ = writeln!(usart, "\nDone.");
+    loop {
+        Timer::after_secs(5).await;
+    }
+}

--- a/examples/sf32lb52x/src/bin/i2c_light.rs
+++ b/examples/sf32lb52x/src/bin/i2c_light.rs
@@ -1,0 +1,209 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use embedded_io::Write;
+use sifli_hal::i2c::{self, I2c};
+use sifli_hal::usart::{Config as UartConfig, Uart};
+use {defmt_rtt as _, panic_probe as _};
+
+// Ambient light sensor example: LTR-303ALS-01
+//
+// Hardware:
+//   I2C3: PA40 (SCL), PA39 (SDA)
+//   PA38, PA30: Sensor board power enables
+//   PA18/PA19: UART1 TX/RX (debug, 1Mbps)
+//
+// Device:
+//   LTR-303ALS-01 @ 0x29 - Ambient Light Sensor (CH0 visible+IR, CH1 IR only)
+
+// --- LTR-303ALS-01 registers ---
+const LTR_ADDR: u8 = 0x29;
+const LTR_ALS_CONTR: u8 = 0x80; // Control register (gain, active mode)
+const LTR_ALS_MEAS_RATE: u8 = 0x85; // Measurement rate + integration time
+const LTR_PART_ID: u8 = 0x86; // Part ID (expect 0xA0)
+const LTR_MANUFAC_ID: u8 = 0x87; // Manufacturer ID (expect 0x05)
+const LTR_ALS_STATUS: u8 = 0x8C; // ALS status
+const LTR_ALS_DATA_CH1_0: u8 = 0x88; // CH1 low byte (read CH1 first, then CH0)
+// CH1 high = 0x89, CH0 low = 0x8A, CH0 high = 0x8B
+
+// ALS_CONTR register bits
+const ALS_MODE_ACTIVE: u8 = 0x01; // Bit 0: active mode
+const ALS_GAIN_1X: u8 = 0x00; // Bits [4:2]: gain = 1x (1-64k lux)
+const ALS_GAIN_4X: u8 = 0x08; // gain = 4x
+const ALS_GAIN_8X: u8 = 0x0C; // gain = 8x
+const ALS_GAIN_48X: u8 = 0x18; // gain = 48x
+const ALS_GAIN_96X: u8 = 0x1C; // gain = 96x (0.01-600 lux)
+
+/// Read a single register
+fn read_reg(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>, reg: u8) -> Result<u8, i2c::Error> {
+    let mut buf = [0u8; 1];
+    i2c.blocking_write_read(LTR_ADDR, &[reg], &mut buf)?;
+    Ok(buf[0])
+}
+
+/// Write a single register
+fn write_reg(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>, reg: u8, val: u8) -> Result<(), i2c::Error> {
+    i2c.blocking_write(LTR_ADDR, &[reg, val])
+}
+
+/// Initialize LTR-303: 1x gain, 100ms integration, 500ms measurement rate
+fn init_ltr303(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>, usart: &mut impl Write) -> bool {
+    // Check Part ID
+    match read_reg(i2c, LTR_PART_ID) {
+        Ok(id) => {
+            let _ = writeln!(usart, "LTR-303 Part ID: 0x{:02X} (expect 0xA0)", id);
+        }
+        Err(e) => {
+            let _ = writeln!(usart, "LTR-303 not found: {:?}", defmt::Debug2Format(&e));
+            return false;
+        }
+    }
+
+    // Check Manufacturer ID
+    if let Ok(id) = read_reg(i2c, LTR_MANUFAC_ID) {
+        let _ = writeln!(usart, "LTR-303 Manufacturer ID: 0x{:02X} (expect 0x05)", id);
+    }
+
+    // ALS_MEAS_RATE: integration time = 100ms (000), measurement rate = 500ms (011)
+    // Bits [5:3] = integration time, Bits [2:0] = measurement rate
+    // 000_011 = 0x03
+    let _ = write_reg(i2c, LTR_ALS_MEAS_RATE, 0x03);
+
+    // ALS_CONTR: Gain 1x, Active mode
+    let _ = write_reg(i2c, LTR_ALS_CONTR, ALS_GAIN_1X | ALS_MODE_ACTIVE);
+
+    let _ = writeln!(usart, "LTR-303 initialized (1x gain, 100ms integration, 500ms rate)");
+    true
+}
+
+/// Read ALS data (CH0 = visible+IR, CH1 = IR only)
+/// Returns (ch0, ch1) raw values, or None if no new data
+fn read_ltr303(i2c: &mut I2c<'_, impl i2c::Instance, impl sifli_hal::mode::Mode>) -> Option<(u16, u16)> {
+    // Check status
+    let status = read_reg(i2c, LTR_ALS_STATUS).ok()?;
+    if status & 0x04 == 0 {
+        return None; // No new data
+    }
+
+    // Must read CH1 first, then CH0 (per datasheet)
+    // Read 4 bytes starting from CH1_0 (0x88): CH1_L, CH1_H, CH0_L, CH0_H
+    let mut buf = [0u8; 4];
+    i2c.blocking_write_read(LTR_ADDR, &[LTR_ALS_DATA_CH1_0], &mut buf).ok()?;
+
+    let ch1 = (buf[1] as u16) << 8 | buf[0] as u16;
+    let ch0 = (buf[3] as u16) << 8 | buf[2] as u16;
+
+    Some((ch0, ch1))
+}
+
+/// Calculate approximate lux from CH0 and CH1 raw values
+/// Simplified formula from LTR-303 application note (gain=1x, integration=100ms)
+fn calculate_lux(ch0: u16, ch1: u16) -> u32 {
+    if ch0 == 0 {
+        return 0;
+    }
+
+    let c0 = ch0 as u32;
+    let c1 = ch1 as u32;
+    let ratio = c1 * 100 / c0;
+
+    // Lux formula depends on CH1/CH0 ratio
+    // Coefficients from LTR-303 application note (gain=1x, integration=100ms)
+    if ratio < 45 {
+        (17743 * c0 + 11059 * c1) / 10000
+    } else if ratio < 64 {
+        (42785 * c0 - 19548 * c1) / 10000
+    } else if ratio < 85 {
+        (5926 * c0 + 1185 * c1) / 10000
+    } else if ratio <= 100 {
+        // Mostly IR, very little visible
+        (5926 * c0 + 1185 * c1) / 10000
+    } else {
+        // CH1 > CH0: dominant IR source (e.g., incandescent, dark with IR noise)
+        // Return a rough estimate based on visible portion
+        if c0 > c1 { 0 } else { c0 / 10 }
+    }
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = sifli_hal::init(Default::default());
+
+    // UART debug
+    let mut uart_config = UartConfig::default();
+    uart_config.baudrate = 1000000;
+    let mut usart = Uart::new_blocking(p.USART1, p.PA18, p.PA19, uart_config).unwrap();
+
+    let _ = writeln!(usart, "\r\n=== Ambient Light Sensor Example ===");
+    let _ = writeln!(usart, "LTR-303ALS-01\r\n");
+
+    // Enable sensor board power
+    sifli_hal::pac::PMUC.peri_ldo().modify(|w| {
+        w.set_en_vdd33_ldo3(true);
+        w.set_vdd33_ldo3_pd(false);
+    });
+    {
+        let en1 = sifli_hal::gpio::Output::new(&mut p.PA38, sifli_hal::gpio::Level::High);
+        let en2 = sifli_hal::gpio::Output::new(&mut p.PA30, sifli_hal::gpio::Level::High);
+        core::mem::forget(en1);
+        core::mem::forget(en2);
+    }
+    Timer::after_millis(100).await;
+
+    // Create blocking I2C
+    let mut i2c = I2c::new_blocking(p.I2C3, p.PA40, p.PA39, i2c::Config::default());
+
+    // Initialize sensor
+    if !init_ltr303(&mut i2c, &mut usart) {
+        let _ = writeln!(usart, "Failed to initialize LTR-303!");
+        loop { Timer::after_secs(1).await; }
+    }
+
+    // Wait for first measurement
+    Timer::after_millis(200).await;
+
+    let _ = writeln!(usart, "\nReading light data...\r\n");
+
+    let mut gain = 0u8; // Current gain setting index
+
+    loop {
+        if let Some((ch0, ch1)) = read_ltr303(&mut i2c) {
+            let lux = calculate_lux(ch0, ch1);
+            let _ = writeln!(usart,
+                "CH0={:5} CH1={:5} ratio={:3}% lux~{:5}",
+                ch0, ch1,
+                if ch0 > 0 { (ch1 as u32 * 100 / ch0 as u32) as u16 } else { 0 },
+                lux,
+            );
+
+            // Auto-gain: switch gain if reading is too low or saturated
+            if ch0 < 100 && gain < 4 {
+                gain += 1;
+                let gain_val = match gain {
+                    1 => ALS_GAIN_4X,
+                    2 => ALS_GAIN_8X,
+                    3 => ALS_GAIN_48X,
+                    _ => ALS_GAIN_96X,
+                };
+                let _ = write_reg(&mut i2c, LTR_ALS_CONTR, gain_val | ALS_MODE_ACTIVE);
+                let _ = writeln!(usart, "  -> Gain increased to {}x",
+                    match gain { 1 => 4, 2 => 8, 3 => 48, _ => 96 });
+            } else if ch0 > 50000 && gain > 0 {
+                gain -= 1;
+                let gain_val = match gain {
+                    0 => ALS_GAIN_1X,
+                    1 => ALS_GAIN_4X,
+                    2 => ALS_GAIN_8X,
+                    _ => ALS_GAIN_48X,
+                };
+                let _ = write_reg(&mut i2c, LTR_ALS_CONTR, gain_val | ALS_MODE_ACTIVE);
+                let _ = writeln!(usart, "  -> Gain decreased to {}x",
+                    match gain { 0 => 1, 1 => 4, 2 => 8, _ => 48 });
+            }
+        }
+
+        Timer::after_millis(500).await;
+    }
+}

--- a/examples/sf32lb52x/src/bin/i2c_scan.rs
+++ b/examples/sf32lb52x/src/bin/i2c_scan.rs
@@ -1,0 +1,156 @@
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use embedded_io::Write;
+use sifli_hal::i2c::{self, I2c};
+use sifli_hal::usart::{Config as UartConfig, Uart};
+use {defmt_rtt as _, panic_probe as _};
+
+// I2C bus scanner
+//
+// Hardware connection:
+//   PA40 (SCL) -> I2C bus SCL (with pull-up)
+//   PA39 (SDA) -> I2C bus SDA (with pull-up)
+//   PA18/PA19  -> UART1 TX/RX (debug)
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = sifli_hal::init(Default::default());
+
+    // UART debug output
+    let mut uart_config = UartConfig::default();
+    uart_config.baudrate = 1000000;
+    let mut usart = Uart::new_blocking(p.USART1, p.PA18, p.PA19, uart_config).unwrap();
+
+    let _ = writeln!(usart, "\r\n=== I2C Bus Scanner ===");
+
+    // Enable sensor power (board-specific)
+    // LDO3 for general peripheral power
+    sifli_hal::pac::PMUC.peri_ldo().modify(|w| {
+        w.set_en_vdd33_ldo3(true);
+        w.set_vdd33_ldo3_pd(false);
+    });
+    // PA38 and PA30: sensor board power enables (from raw debug example)
+    {
+        let mut en1 = sifli_hal::gpio::Output::new(&mut p.PA38, sifli_hal::gpio::Level::High);
+        let mut en2 = sifli_hal::gpio::Output::new(&mut p.PA30, sifli_hal::gpio::Level::High);
+        en1.set_high();
+        en2.set_high();
+        // Keep them alive by leaking (they must stay high)
+        core::mem::forget(en1);
+        core::mem::forget(en2);
+    }
+    Timer::after_millis(100).await;
+
+    // Diagnostic: Read raw GPIO state of PA39/PA40 after power enable
+    {
+        let pa39_in = sifli_hal::gpio::Input::new(&mut p.PA39, sifli_hal::gpio::Pull::Up);
+        let pa40_in = sifli_hal::gpio::Input::new(&mut p.PA40, sifli_hal::gpio::Pull::Up);
+        sifli_hal::cortex_m_blocking_delay_us(100);
+        let _ = writeln!(usart, "GPIO test (pull-up, after pwr): PA39(SDA)={}, PA40(SCL)={}",
+            if pa39_in.is_high() { "HIGH" } else { "LOW" },
+            if pa40_in.is_high() { "HIGH" } else { "LOW" });
+        drop(pa39_in);
+        drop(pa40_in);
+    }
+
+    // Create I2C3 on PA40 (SCL) / PA39 (SDA)
+    let mut i2c = I2c::new_blocking(p.I2C3, p.PA40, p.PA39, i2c::Config::default());
+
+    // Dump I2C3 registers for debugging
+    {
+        let i2c3 = sifli_hal::pac::I2C3;
+        let cr = i2c3.cr().read();
+        let sr = i2c3.sr().read();
+        let lcr = i2c3.lcr().read();
+        let wcr = i2c3.wcr().read();
+        let bmr = i2c3.bmr().read();
+        let _ = writeln!(usart, "I2C3 registers after init:");
+        let _ = writeln!(usart, "  CR:  0x{:08X} (MODE={}, SCLE={}, IUE={})",
+            cr.0, cr.mode(), cr.scle(), cr.iue());
+        let _ = writeln!(usart, "  SR:  0x{:08X} (UB={}, TE={}, BED={}, ALD={})",
+            sr.0, sr.ub(), sr.te(), sr.bed(), sr.ald());
+        let _ = writeln!(usart, "  LCR: 0x{:08X} (FLV={}, SLV={})",
+            lcr.0, lcr.flv(), lcr.slv());
+        let _ = writeln!(usart, "  WCR: 0x{:08X} (CNT={})", wcr.0, wcr.cnt());
+        let _ = writeln!(usart, "  BMR: 0x{:08X} (SCL={}, SDA={})",
+            bmr.0, bmr.scl(), bmr.sda());
+
+        // Dump PINR
+        let pinr = sifli_hal::pac::HPSYS_CFG.i2c3_pinr().read();
+        let _ = writeln!(usart, "  PINR: 0x{:08X} (SCL_PIN={}, SDA_PIN={})",
+            pinr.0, pinr.scl_pin(), pinr.sda_pin());
+
+        // Dump PINMUX for PA39 (SDA) and PA40 (SCL)
+        let pa39 = sifli_hal::pac::HPSYS_PINMUX.pad_pa39_42(0).read();
+        let pa40 = sifli_hal::pac::HPSYS_PINMUX.pad_pa39_42(1).read();
+        let _ = writeln!(usart, "  PA39 PINMUX: 0x{:08X} (FSEL={}, IE={}, PE={}, PS={:?})",
+            pa39.0, pa39.fsel(), pa39.ie(), pa39.pe(), pa39.ps());
+        let _ = writeln!(usart, "  PA40 PINMUX: 0x{:08X} (FSEL={}, IE={}, PE={}, PS={:?})",
+            pa40.0, pa40.fsel(), pa40.ie(), pa40.pe(), pa40.ps());
+
+        // Check BMR again after a small delay
+        sifli_hal::cortex_m_blocking_delay_us(100);
+        let bmr2 = i2c3.bmr().read();
+        let _ = writeln!(usart, "  BMR (after delay): SCL={}, SDA={}", bmr2.scl(), bmr2.sda());
+    }
+
+    let _ = writeln!(usart, "I2C3 initialized (100kHz, PA40=SCL, PA39=SDA)");
+    let _ = writeln!(usart, "Scanning addresses 0x08-0x77...\n");
+
+    // Print header
+    let _ = write!(usart, "     0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F");
+
+    let mut found = 0u32;
+
+    for addr in 0x00..0x80u8 {
+        if addr % 16 == 0 {
+            let _ = write!(usart, "\r\n{:02X}:", addr);
+        }
+
+        if addr < 0x08 || addr > 0x77 {
+            let _ = write!(usart, "   ");
+            continue;
+        }
+
+        // Probe: try writing zero bytes (address-only)
+        let t0 = embassy_time::Instant::now();
+        match i2c.blocking_write(addr, &[]) {
+            Ok(_) => {
+                let _ = write!(usart, " {:02X}", addr);
+                found += 1;
+            }
+            Err(_) => {
+                let _ = write!(usart, " --");
+            }
+        }
+    }
+
+    let _ = writeln!(usart, "\n\n{} device(s) found.\n", found);
+
+    // If devices found, try reading WHO_AM_I from known sensors
+    if found > 0 {
+        let _ = writeln!(usart, "Probing known sensors:");
+
+        // MMC5603NJ magnetometer (0x30, WHO_AM_I register 0x39)
+        let mut buf = [0u8; 1];
+        if i2c.blocking_write_read(0x30, &[0x39], &mut buf).is_ok() {
+            let _ = writeln!(usart, "  0x30: WHO_AM_I = 0x{:02X} (MMC5603: expect 0x10)", buf[0]);
+        }
+
+        // LSM6DSx IMU (0x6A or 0x6B, WHO_AM_I register 0x0F)
+        for addr in [0x6Au8, 0x6B] {
+            if i2c.blocking_write_read(addr, &[0x0F], &mut buf).is_ok() {
+                let _ = writeln!(usart, "  0x{:02X}: WHO_AM_I = 0x{:02X} (LSM6DSx)", addr, buf[0]);
+            }
+        }
+    }
+
+    let _ = writeln!(usart, "\nDone. Entering idle loop.");
+
+    loop {
+        Timer::after_secs(1).await;
+    }
+}

--- a/sifli-hal/data/sf32lb52x/pinmux_signals.yaml
+++ b/sifli-hal/data/sf32lb52x/pinmux_signals.yaml
@@ -49,6 +49,13 @@ hcpu:
     pin_trait:
       crate::usart::$cfg_pin<$peripheral>
 
+  # Muxed Peripheral: I2C
+  # Uses register lookup to determine the specific pin trait (e.g., SclPin, SdaPin).
+  - name: I2C
+    type: peripheral_mux
+    pin_trait:
+      crate::i2c::$cfg_pin<$peripheral>
+
   # No-Mux Peripheral: LCDC SPI
   # Uses Regex to match multiple signals (RSTB, TS, etc.) with a single rule.
   # dynamic substitution:

--- a/sifli-hal/src/i2c.rs
+++ b/sifli-hal/src/i2c.rs
@@ -1,0 +1,924 @@
+//! Inter-Integrated Circuit (I2C) bus driver
+//!
+//! SiFli I2C controller implementation based on DesignWare I2C IP.
+//!
+//! Supports both blocking and async (interrupt-driven) modes.
+//!
+//! # Example (blocking)
+//! ```ignore
+//! let i2c = i2c::I2c::new_blocking(
+//!     p.I2C3, p.PA40, p.PA39,
+//!     i2c::Config::default(),
+//! );
+//! let mut buf = [0u8; 1];
+//! i2c.blocking_write_read(0x30, &[0x39], &mut buf).unwrap();
+//! ```
+//!
+//! # Example (async)
+//! ```ignore
+//! bind_interrupts!(struct Irqs {
+//!     I2C3 => i2c::InterruptHandler<peripherals::I2C3>;
+//! });
+//! let i2c = i2c::I2c::new(
+//!     p.I2C3, p.PA40, p.PA39,
+//!     Irqs, i2c::Config::default(),
+//! );
+//! let mut buf = [0u8; 1];
+//! i2c.write_read(0x30, &[0x39], &mut buf).await.unwrap();
+//! ```
+#![macro_use]
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{compiler_fence, Ordering};
+use core::task::Poll;
+
+use embassy_hal_internal::{into_ref, PeripheralRef};
+use embassy_sync::waitqueue::AtomicWaker;
+use embassy_time::{Duration, Instant};
+
+use crate::gpio::{AfType, Pull, SealedPin};
+use crate::interrupt::typelevel::Interrupt as _;
+use crate::mode::{Async, Blocking, Mode};
+use crate::pac::i2c::I2c as Regs;
+use crate::time::Hertz;
+use crate::{interrupt, rcc, Peripheral};
+
+/// I2C error
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Bus error
+    Bus,
+    /// Arbitration loss
+    Arbitration,
+    /// NACK received
+    Nack,
+    /// Timeout
+    Timeout,
+    /// Overrun/underrun
+    Overrun,
+    /// Zero-length transfer
+    ZeroLength,
+}
+
+/// I2C configuration
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug)]
+pub struct Config {
+    /// I2C bus frequency (default: 100 kHz standard mode)
+    pub frequency: Hertz,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            frequency: Hertz(100_000),
+        }
+    }
+}
+
+/// I2C bus mode
+#[repr(u8)]
+#[derive(Debug, Copy, Clone)]
+enum BusMode {
+    Standard = 0b00,
+    Fast = 0b01,
+}
+
+const TIMEOUT_MS: u64 = 1000;
+
+/// Interrupt handler for async I2C operations.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let regs = T::regs();
+        let sr = regs.sr().read();
+        let state = T::state();
+
+        let has_event = sr.te() || sr.rf() || sr.bed() || sr.ald() || sr.dmadone();
+
+        if has_event {
+            // Disable interrupts that fired to prevent re-entry
+            regs.ier().modify(|w| {
+                if sr.te() {
+                    w.set_teie(false);
+                }
+                if sr.rf() {
+                    w.set_rfie(false);
+                }
+                if sr.bed() {
+                    w.set_bedie(false);
+                }
+                if sr.ald() {
+                    w.set_aldie(false);
+                }
+                if sr.dmadone() {
+                    w.set_dmadoneie(false);
+                }
+            });
+
+            compiler_fence(Ordering::SeqCst);
+            state.waker.wake();
+        }
+    }
+}
+
+/// I2C driver
+pub struct I2c<'d, T: Instance, M: Mode> {
+    _peri: PeripheralRef<'d, T>,
+    _phantom: PhantomData<M>,
+}
+
+impl<'d, T: Instance> I2c<'d, T, Blocking> {
+    /// Create a new blocking I2C driver
+    pub fn new_blocking(
+        peri: impl Peripheral<P = T> + 'd,
+        scl: impl Peripheral<P = impl SclPin<T>> + 'd,
+        sda: impl Peripheral<P = impl SdaPin<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        into_ref!(peri, scl, sda);
+
+        // Enable I2C clock and reset
+        rcc::enable_and_reset::<T>();
+
+        // Configure pins: set FSEL (AF function) and PINR routing
+        let scl_ref = new_pin!(scl, AfType::new(Pull::Up));
+        let sda_ref = new_pin!(sda, AfType::new(Pull::Up));
+
+        // I2C requires input enabled on both SCL and SDA (bidirectional)
+        {
+            use crate::gpio::hpsys::HpsysPin;
+            let scl_pin_ref = scl_ref.as_ref().unwrap();
+            let sda_pin_ref = sda_ref.as_ref().unwrap();
+            let mut scl_hw = HpsysPin::new(scl_pin_ref.pin_bank());
+            let mut sda_hw = HpsysPin::new(sda_pin_ref.pin_bank());
+            scl_hw.set_ie(true);
+            sda_hw.set_ie(true);
+        }
+
+        // Initialize hardware
+        Self::init(config);
+
+        Self {
+            _peri: peri,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'d, T: Instance> I2c<'d, T, Async> {
+    /// Create a new async I2C driver
+    pub fn new(
+        peri: impl Peripheral<P = T> + 'd,
+        scl: impl Peripheral<P = impl SclPin<T>> + 'd,
+        sda: impl Peripheral<P = impl SdaPin<T>> + 'd,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Self {
+        into_ref!(peri, scl, sda);
+
+        // Enable I2C clock and reset
+        rcc::enable_and_reset::<T>();
+
+        // Configure pins
+        let scl_ref = new_pin!(scl, AfType::new(Pull::Up));
+        let sda_ref = new_pin!(sda, AfType::new(Pull::Up));
+
+        {
+            use crate::gpio::hpsys::HpsysPin;
+            let scl_pin_ref = scl_ref.as_ref().unwrap();
+            let sda_pin_ref = sda_ref.as_ref().unwrap();
+            let mut scl_hw = HpsysPin::new(scl_pin_ref.pin_bank());
+            let mut sda_hw = HpsysPin::new(sda_pin_ref.pin_bank());
+            scl_hw.set_ie(true);
+            sda_hw.set_ie(true);
+        }
+
+        // Initialize hardware
+        Self::init(config);
+
+        // Enable interrupt
+        T::Interrupt::unpend();
+        unsafe { T::Interrupt::enable() };
+
+        Self {
+            _peri: peri,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Async write
+    pub async fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+        let regs = T::regs();
+        let timeout = Duration::from_millis(TIMEOUT_MS);
+
+        regs.cr().modify(|w| w.set_iue(false));
+        regs.cr().modify(|w| w.set_iue(true));
+
+        self.async_wait_bus_idle(timeout).await?;
+        clear_flags(regs);
+
+        // Send START + address (write)
+        regs.dbr().write(|w| w.set_data(addr << 1));
+
+        regs.tcr().write(|w| {
+            w.set_tb(true);
+            w.set_start(true);
+        });
+
+        self.async_wait_te(timeout).await?;
+        if let Err(e) = check_nack(regs) {
+            stop_and_cleanup(regs);
+            return Err(e);
+        }
+
+        if bytes.is_empty() {
+            // Probe only: address ACKed, send STOP
+            stop_and_cleanup(regs);
+            return Ok(());
+        }
+
+        for (i, byte) in bytes.iter().enumerate() {
+            regs.sr().write(|w| w.set_te(true));
+            regs.dbr().write(|w| w.set_data(*byte));
+            if i == bytes.len() - 1 {
+                regs.tcr().write(|w| {
+                    w.set_tb(true);
+                    w.set_stop(true);
+                });
+            } else {
+                regs.tcr().write(|w| w.set_tb(true));
+            }
+            self.async_wait_te(timeout).await?;
+            if let Err(e) = check_nack(regs) {
+                stop_and_cleanup(regs);
+                return Err(e);
+            }
+        }
+
+        self.async_wait_bus_idle(timeout).await?;
+        regs.cr().modify(|w| w.set_iue(false));
+        Ok(())
+    }
+
+    /// Async read
+    pub async fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Err(Error::ZeroLength);
+        }
+
+        let regs = T::regs();
+        let timeout = Duration::from_millis(TIMEOUT_MS);
+
+        regs.cr().modify(|w| w.set_iue(false));
+        regs.cr().modify(|w| w.set_iue(true));
+
+        self.async_wait_bus_idle(timeout).await?;
+        clear_flags(regs);
+
+        // Send START + address (read)
+        regs.dbr().write(|w| w.set_data((addr << 1) | 1));
+        regs.tcr().write(|w| {
+            w.set_tb(true);
+            w.set_start(true);
+        });
+
+        self.async_wait_te(timeout).await?;
+        if let Err(e) = check_nack(regs) {
+            stop_and_cleanup(regs);
+            return Err(e);
+        }
+
+        let len = buffer.len();
+        for (i, byte) in buffer.iter_mut().enumerate() {
+            regs.sr().write(|w| w.set_rf(true));
+            if i == len - 1 {
+                regs.tcr().write(|w| {
+                    w.set_tb(true);
+                    w.set_stop(true);
+                    w.set_nack(true);
+                });
+            } else {
+                regs.tcr().write(|w| w.set_tb(true));
+            }
+            self.async_wait_rf(timeout).await?;
+            *byte = regs.dbr().read().data();
+        }
+
+        self.async_wait_bus_idle(timeout).await?;
+        regs.cr().modify(|w| w.set_iue(false));
+        Ok(())
+    }
+
+    /// Async write then read (repeated START)
+    pub async fn write_read(
+        &mut self,
+        addr: u8,
+        write: &[u8],
+        read: &mut [u8],
+    ) -> Result<(), Error> {
+        if write.is_empty() || read.is_empty() {
+            return Err(Error::ZeroLength);
+        }
+
+        let regs = T::regs();
+        let timeout = Duration::from_millis(TIMEOUT_MS);
+
+        regs.cr().modify(|w| w.set_iue(false));
+        regs.cr().modify(|w| w.set_iue(true));
+
+        self.async_wait_bus_idle(timeout).await?;
+        clear_flags(regs);
+
+        // Write phase
+        regs.dbr().write(|w| w.set_data(addr << 1));
+        regs.tcr().write(|w| {
+            w.set_tb(true);
+            w.set_start(true);
+        });
+        self.async_wait_te(timeout).await?;
+        if let Err(e) = check_nack(regs) {
+            stop_and_cleanup(regs);
+            return Err(e);
+        }
+
+        for byte in write.iter() {
+            regs.sr().write(|w| w.set_te(true));
+            regs.dbr().write(|w| w.set_data(*byte));
+            regs.tcr().write(|w| w.set_tb(true));
+            self.async_wait_te(timeout).await?;
+            if let Err(e) = check_nack(regs) {
+                stop_and_cleanup(regs);
+                return Err(e);
+            }
+        }
+
+        // Read phase (repeated START)
+        regs.sr().write(|w| w.set_te(true));
+        regs.dbr().write(|w| w.set_data((addr << 1) | 1));
+        regs.tcr().write(|w| {
+            w.set_tb(true);
+            w.set_start(true);
+        });
+        self.async_wait_te(timeout).await?;
+        if let Err(e) = check_nack(regs) {
+            stop_and_cleanup(regs);
+            return Err(e);
+        }
+
+        let read_len = read.len();
+        for (i, byte) in read.iter_mut().enumerate() {
+            regs.sr().write(|w| w.set_rf(true));
+            if i == read_len - 1 {
+                regs.tcr().write(|w| {
+                    w.set_tb(true);
+                    w.set_stop(true);
+                    w.set_nack(true);
+                });
+            } else {
+                regs.tcr().write(|w| w.set_tb(true));
+            }
+            self.async_wait_rf(timeout).await?;
+            *byte = regs.dbr().read().data();
+        }
+
+        self.async_wait_bus_idle(timeout).await?;
+        regs.cr().modify(|w| w.set_iue(false));
+        Ok(())
+    }
+
+    async fn async_wait_te(&self, timeout: Duration) -> Result<(), Error> {
+        let regs = T::regs();
+        let state = T::state();
+        let start = Instant::now();
+
+        // Check if already set
+        if regs.sr().read().te() {
+            return Ok(());
+        }
+
+        // Enable TE interrupt
+        regs.ier().modify(|w| w.set_teie(true));
+
+        poll_fn(|cx| {
+            state.waker.register(cx.waker());
+            if regs.sr().read().te() {
+                return Poll::Ready(Ok(()));
+            }
+            if start.elapsed() > timeout {
+                return Poll::Ready(Err(Error::Timeout));
+            }
+            regs.ier().modify(|w| w.set_teie(true));
+            Poll::Pending
+        })
+        .await
+    }
+
+    async fn async_wait_rf(&self, timeout: Duration) -> Result<(), Error> {
+        let regs = T::regs();
+        let state = T::state();
+        let start = Instant::now();
+
+        if regs.sr().read().rf() {
+            return Ok(());
+        }
+
+        regs.ier().modify(|w| w.set_rfie(true));
+
+        poll_fn(|cx| {
+            state.waker.register(cx.waker());
+            if regs.sr().read().rf() {
+                return Poll::Ready(Ok(()));
+            }
+            if start.elapsed() > timeout {
+                return Poll::Ready(Err(Error::Timeout));
+            }
+            regs.ier().modify(|w| w.set_rfie(true));
+            Poll::Pending
+        })
+        .await
+    }
+
+    async fn async_wait_bus_idle(&self, timeout: Duration) -> Result<(), Error> {
+        let regs = T::regs();
+        let start = Instant::now();
+
+        loop {
+            if !regs.sr().read().ub() {
+                return Ok(());
+            }
+            if start.elapsed() > timeout {
+                return Err(Error::Timeout);
+            }
+            embassy_futures::yield_now().await;
+        }
+    }
+}
+
+// Common initialization and blocking implementations
+impl<'d, T: Instance, M: Mode> I2c<'d, T, M> {
+    /// Initialize I2C hardware registers.
+    /// Matches rcc-v2 (known working) init sequence.
+    fn init(config: Config) {
+        let i2c_clk = T::frequency().expect("I2C clock not configured");
+        let (lcr_val, wcr_val) = compute_timing(i2c_clk, config.frequency);
+
+        let regs = T::regs();
+
+        // Module reset using modify to preserve register structure
+        regs.cr().modify(|w| w.set_ur(true));
+        crate::cortex_m_blocking_delay_us(100);
+        regs.cr().modify(|w| w.set_ur(false));
+
+        // Check bus state and attempt recovery if needed
+        let bmr = regs.bmr().read();
+        if bmr.scl() && bmr.sda() {
+            // Both lines high - send clock cycles for bus recovery (slave might be stuck)
+            regs.cr().modify(|w| w.set_rstreq(true));
+            let start = Instant::now();
+            while regs.cr().read().rstreq() {
+                if start.elapsed() > Duration::from_millis(10) {
+                    break;
+                }
+            }
+        }
+
+        let bus_mode = if config.frequency.0 <= 100_000 {
+            BusMode::Standard
+        } else {
+            BusMode::Fast
+        };
+
+        // Set CR: mode + SCLE + IUE (matching rcc-v2 working init)
+        regs.cr().write(|w| {
+            w.set_mode(bus_mode as u8);
+            w.set_scle(true);
+            w.set_iue(true);
+        });
+
+        // Disable all interrupts
+        regs.ier().write(|_| {});
+
+        // Set reset cycle count
+        regs.rccr().write(|w| w.set_rstcyc(9));
+
+        // Set timing
+        regs.lcr().write(|w| {
+            w.set_flv(lcr_val);
+            w.set_slv(0x1FF);
+        });
+        regs.wcr().write(|w| w.set_cnt(wcr_val));
+    }
+
+    /// Blocking write to an I2C device
+    pub fn blocking_write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Error> {
+        let regs = T::regs();
+        let timeout = Duration::from_millis(TIMEOUT_MS);
+
+        regs.cr().modify(|w| w.set_iue(false));
+        regs.cr().modify(|w| w.set_iue(true));
+
+        wait_bus_idle(regs, timeout)?;
+        clear_flags(regs);
+
+        // Send START + address (write)
+        regs.dbr().write(|w| w.set_data(addr << 1));
+
+        regs.tcr().write(|w| {
+            w.set_tb(true);
+            w.set_start(true);
+        });
+
+        wait_te(regs, timeout)?;
+        if let Err(e) = check_nack(regs) {
+            stop_and_cleanup(regs);
+            return Err(e);
+        }
+
+        if bytes.is_empty() {
+            // Probe only: address ACKed, send STOP
+            stop_and_cleanup(regs);
+            return Ok(());
+        }
+
+        // Send data bytes
+        for (i, byte) in bytes.iter().enumerate() {
+            // Clear TE flag before next byte
+            regs.sr().write(|w| w.set_te(true));
+
+            regs.dbr().write(|w| w.set_data(*byte));
+            if i == bytes.len() - 1 {
+                regs.tcr().write(|w| {
+                    w.set_tb(true);
+                    w.set_stop(true);
+                });
+            } else {
+                regs.tcr().write(|w| w.set_tb(true));
+            }
+
+            wait_te(regs, timeout)?;
+            if let Err(e) = check_nack(regs) {
+                stop_and_cleanup(regs);
+                return Err(e);
+            }
+        }
+
+        wait_bus_idle(regs, timeout)?;
+        regs.cr().modify(|w| w.set_iue(false));
+        Ok(())
+    }
+
+    /// Blocking read from an I2C device
+    pub fn blocking_read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Err(Error::ZeroLength);
+        }
+
+        let regs = T::regs();
+        let timeout = Duration::from_millis(TIMEOUT_MS);
+
+        regs.cr().modify(|w| w.set_iue(false));
+        regs.cr().modify(|w| w.set_iue(true));
+
+        wait_bus_idle(regs, timeout)?;
+        clear_flags(regs);
+
+        // Send START + address (read)
+        regs.dbr().write(|w| w.set_data((addr << 1) | 1));
+        regs.tcr().write(|w| {
+            w.set_tb(true);
+            w.set_start(true);
+        });
+
+        wait_te(regs, timeout)?;
+        if let Err(e) = check_nack(regs) {
+            stop_and_cleanup(regs);
+            return Err(e);
+        }
+
+        let len = buffer.len();
+        for (i, byte) in buffer.iter_mut().enumerate() {
+            // Clear RF flag
+            regs.sr().write(|w| w.set_rf(true));
+
+            if i == len - 1 {
+                regs.tcr().write(|w| {
+                    w.set_tb(true);
+                    w.set_stop(true);
+                    w.set_nack(true);
+                });
+            } else {
+                regs.tcr().write(|w| w.set_tb(true));
+            }
+
+            wait_rf(regs, timeout)?;
+            *byte = regs.dbr().read().data();
+        }
+
+        wait_bus_idle(regs, timeout)?;
+        regs.cr().modify(|w| w.set_iue(false));
+        Ok(())
+    }
+
+    /// Blocking write then read (combined with repeated START)
+    pub fn blocking_write_read(
+        &mut self,
+        addr: u8,
+        write: &[u8],
+        read: &mut [u8],
+    ) -> Result<(), Error> {
+        if write.is_empty() || read.is_empty() {
+            return Err(Error::ZeroLength);
+        }
+
+        let regs = T::regs();
+        let timeout = Duration::from_millis(TIMEOUT_MS);
+
+        regs.cr().modify(|w| w.set_iue(false));
+        regs.cr().modify(|w| w.set_iue(true));
+
+        wait_bus_idle(regs, timeout)?;
+        clear_flags(regs);
+
+        // Write phase
+        regs.dbr().write(|w| w.set_data(addr << 1));
+        regs.tcr().write(|w| {
+            w.set_tb(true);
+            w.set_start(true);
+        });
+        wait_te(regs, timeout)?;
+        if let Err(e) = check_nack(regs) {
+            stop_and_cleanup(regs);
+            return Err(e);
+        }
+
+        for byte in write.iter() {
+            regs.sr().write(|w| w.set_te(true));
+            regs.dbr().write(|w| w.set_data(*byte));
+            regs.tcr().write(|w| w.set_tb(true));
+            wait_te(regs, timeout)?;
+            if let Err(e) = check_nack(regs) {
+                stop_and_cleanup(regs);
+                return Err(e);
+            }
+        }
+
+        // Read phase (repeated START)
+        regs.sr().write(|w| w.set_te(true));
+        regs.dbr().write(|w| w.set_data((addr << 1) | 1));
+        regs.tcr().write(|w| {
+            w.set_tb(true);
+            w.set_start(true);
+        });
+        wait_te(regs, timeout)?;
+        if let Err(e) = check_nack(regs) {
+            stop_and_cleanup(regs);
+            return Err(e);
+        }
+
+        let read_len = read.len();
+        for (i, byte) in read.iter_mut().enumerate() {
+            regs.sr().write(|w| w.set_rf(true));
+            if i == read_len - 1 {
+                regs.tcr().write(|w| {
+                    w.set_tb(true);
+                    w.set_stop(true);
+                    w.set_nack(true);
+                });
+            } else {
+                regs.tcr().write(|w| w.set_tb(true));
+            }
+            wait_rf(regs, timeout)?;
+            *byte = regs.dbr().read().data();
+        }
+
+        wait_bus_idle(regs, timeout)?;
+        regs.cr().modify(|w| w.set_iue(false));
+        Ok(())
+    }
+}
+
+// Helper functions - matching rcc-v2 working logic
+
+fn wait_bus_idle(regs: Regs, timeout: Duration) -> Result<(), Error> {
+    let start = Instant::now();
+    while regs.sr().read().ub() {
+        if start.elapsed() > timeout {
+            return Err(Error::Timeout);
+        }
+    }
+    Ok(())
+}
+
+/// Wait for TE (Transmit Empty) flag. Simple poll, no error checking in loop.
+fn wait_te(regs: Regs, timeout: Duration) -> Result<(), Error> {
+    let start = Instant::now();
+    while !regs.sr().read().te() {
+        if start.elapsed() > timeout {
+            return Err(Error::Timeout);
+        }
+    }
+    Ok(())
+}
+
+/// Wait for RF (Receive Full) flag.
+fn wait_rf(regs: Regs, timeout: Duration) -> Result<(), Error> {
+    let start = Instant::now();
+    while !regs.sr().read().rf() {
+        if start.elapsed() > timeout {
+            return Err(Error::Timeout);
+        }
+    }
+    Ok(())
+}
+
+/// Check NACK flag after transfer. Uses SR.NACK (matching rcc-v2).
+fn check_nack(regs: Regs) -> Result<(), Error> {
+    if regs.sr().read().nack() {
+        Err(Error::Nack)
+    } else {
+        Ok(())
+    }
+}
+
+/// Release the bus by sending STOP, waiting briefly, then forcing a module reset
+/// if the bus doesn't go idle. This handles cases where STOP alone doesn't work
+/// (e.g., after address-only probe where device ACKed but no data follows).
+///
+/// Note: module reset (UR) preserves LCR/WCR/RCCR register values, but clears
+/// CR (MODE, SCLE, IUE). The CR is restored after reset.
+fn stop_and_cleanup(regs: Regs) {
+    regs.tcr().write(|w| w.set_stop(true));
+    // Try to wait for bus idle
+    if wait_bus_idle(regs, Duration::from_millis(5)).is_err() {
+        // STOP didn't complete - force module reset and restore CR
+        let cr_saved = regs.cr().read();
+        regs.cr().modify(|w| w.set_ur(true));
+        crate::cortex_m_blocking_delay_us(10);
+        regs.cr().modify(|w| w.set_ur(false));
+        // Restore CR (MODE, SCLE) but with IUE=false
+        regs.cr().write(|w| {
+            w.set_mode(cr_saved.mode());
+            w.set_scle(cr_saved.scle());
+            // IUE intentionally left false
+        });
+    } else {
+        regs.cr().modify(|w| w.set_iue(false));
+    }
+    clear_all_flags(regs);
+}
+
+/// Clear status flags before a new transfer.
+/// Uses modify on W1C register to clear ALL currently set flags
+/// (matching rcc-v2 behavior where modify reads back set bits and writes them to clear).
+fn clear_flags(regs: Regs) {
+    clear_all_flags(regs);
+}
+
+/// Clear all W1C status flags.
+fn clear_all_flags(regs: Regs) {
+    regs.sr().write(|w| {
+        w.set_te(true);
+        w.set_nack(true);
+        w.set_rf(true);
+        w.set_bed(true);
+        w.set_ald(true);
+        w.set_ssd(true);
+        w.set_sad(true);
+        w.set_msd(true);
+        w.set_dmadone(true);
+    });
+}
+
+/// Compute LCR and WCR timing values from clock and target frequency.
+fn compute_timing(i2c_clk: Hertz, target: Hertz) -> (u16, u8) {
+    let dnf = 0u32;
+    let flv = ((i2c_clk.0 + (target.0 / 2)) / target.0 - dnf - 7 + 1) / 2;
+    let flv = flv.min(0x1FF);
+
+    let cnt = flv / 2;
+    let wcr = if cnt < 3 { 0 } else { (cnt - 3).min(0xFF) };
+
+    (flv as u16, wcr as u8)
+}
+
+// --- embedded-hal v1 traits ---
+
+impl embedded_hal_1::i2c::Error for Error {
+    fn kind(&self) -> embedded_hal_1::i2c::ErrorKind {
+        match *self {
+            Error::Bus => embedded_hal_1::i2c::ErrorKind::Bus,
+            Error::Arbitration => embedded_hal_1::i2c::ErrorKind::ArbitrationLoss,
+            Error::Nack => {
+                embedded_hal_1::i2c::ErrorKind::NoAcknowledge(embedded_hal_1::i2c::NoAcknowledgeSource::Unknown)
+            }
+            Error::Overrun => embedded_hal_1::i2c::ErrorKind::Overrun,
+            _ => embedded_hal_1::i2c::ErrorKind::Other,
+        }
+    }
+}
+
+impl<T: Instance, M: Mode> embedded_hal_1::i2c::ErrorType for I2c<'_, T, M> {
+    type Error = Error;
+}
+
+impl<T: Instance, M: Mode> embedded_hal_1::i2c::I2c for I2c<'_, T, M> {
+    fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal_1::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        for op in operations {
+            match op {
+                embedded_hal_1::i2c::Operation::Write(bytes) => {
+                    self.blocking_write(address, bytes)?;
+                }
+                embedded_hal_1::i2c::Operation::Read(buffer) => {
+                    self.blocking_read(address, buffer)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T: Instance> embedded_hal_async::i2c::I2c for I2c<'_, T, Async> {
+    async fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [embedded_hal_1::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        for op in operations {
+            match op {
+                embedded_hal_1::i2c::Operation::Write(bytes) => {
+                    self.write(address, bytes).await?;
+                }
+                embedded_hal_1::i2c::Operation::Read(buffer) => {
+                    self.read(address, buffer).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// --- Instance infrastructure ---
+
+struct State {
+    waker: AtomicWaker,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            waker: AtomicWaker::new(),
+        }
+    }
+}
+
+#[allow(private_interfaces)]
+pub(crate) trait SealedInstance: crate::rcc::RccEnableReset + crate::rcc::RccGetFreq {
+    fn regs() -> Regs;
+    fn state() -> &'static State;
+}
+
+/// I2C peripheral instance trait.
+#[allow(private_bounds)]
+pub trait Instance: Peripheral<P = Self> + SealedInstance + 'static + Send {
+    /// Interrupt for this peripheral.
+    type Interrupt: interrupt::typelevel::Interrupt;
+}
+
+pin_trait!(SclPin, Instance);
+pin_trait!(SdaPin, Instance);
+dma_trait!(Dma, Instance);
+
+macro_rules! impl_i2c {
+    ($inst:ident, $irq:ident) => {
+        #[allow(private_interfaces)]
+        impl SealedInstance for crate::peripherals::$inst {
+            fn regs() -> Regs {
+                crate::pac::$inst
+            }
+
+            fn state() -> &'static State {
+                static STATE: State = State::new();
+                &STATE
+            }
+        }
+
+        impl Instance for crate::peripherals::$inst {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+    };
+}
+
+impl_i2c!(I2C1, I2C1);
+impl_i2c!(I2C2, I2C2);
+impl_i2c!(I2C3, I2C3);
+impl_i2c!(I2C4, I2C4);

--- a/sifli-hal/src/lib.rs
+++ b/sifli-hal/src/lib.rs
@@ -18,6 +18,7 @@ pub mod bt_hci;
 pub mod dma;
 pub mod efuse;
 pub mod gpio;
+pub mod i2c;
 #[cfg(feature = "sf32lb52x")]
 pub mod ipc;
 pub mod lcdc;


### PR DESCRIPTION
Add I2C peripheral driver supporting both blocking and async operation for SF32LB52x. Includes embedded-hal v1 and embedded-hal-async trait implementations, proper bus error recovery with module reset fallback, and interrupt-driven async transfers.

Examples: I2C bus scan, blocking debug, async probe, 9-axis IMU (LSM6DS3TR-C + MMC5603NJ), and ambient light sensor (LTR-303ALS-01).