### PR TITLE
Add clean Dcache option to the LCDC driver

### DIFF
--- a/examples/sf32lb52x/src/bin/lcdc_eg_co5300.rs
+++ b/examples/sf32lb52x/src/bin/lcdc_eg_co5300.rs
@@ -27,7 +27,6 @@ use embedded_graphics::{
     text::Text,
 };
 
-// Import the display driver modules
 use display_driver::bus::QspiFlashBus;
 use display_driver::panel::reset::LCDResetOption;
 use display_driver::{ColorFormat, DisplayDriver};
@@ -36,6 +35,14 @@ use display_driver_co5300::{
     Co5300,
 };
 
+// Note: Although the hardware features a 390x450 display (the standard SiFli bundle), this example
+// renders only a partial area to minimize SRAM usage and maintain code simplicity.
+//
+// To drive the full resolution, it is recommended to utilize PSRAM coupled with
+// partial/block-based rendering.
+//
+// Additionally, due to pixel alignment requirements, the CO5300 controller mandates even-numbered
+// window dimensions (i.e., the refresh area must be a multiple of 2 in both rows and columns).
 const WIDTH: usize = 240;
 const HEIGHT: usize = 240;
 


### PR DESCRIPTION
When utilizing buffers on the stack (both SRAM and PSRAM), it is mandatory to flush the DCache before data transmission. Failure to do so leads to memory inconsistency, resulting in corrupted display output (visual artifacts).