### PR TITLE
refactor(hal/bt_rf_cal): replace magic numbers with named constants, use rwbt crate

### DIFF
--- a/sifli-hal/Cargo.toml
+++ b/sifli-hal/Cargo.toml
@@ -34,10 +34,8 @@ critical-section = "1.2.0"
 cfg-if = { version = "1", features = ["core"] }
 futures-util = { version = "0.3.31", default-features = false }
 nb = "1.1.0"
-musb = { version = "0.3.0", features = [
-    "embassy-usb-driver-impl",
-    "prebuild",
-]}
+musb = { version = "0.3.0", features = ["embassy-usb-driver-impl", "prebuild"] }
+rwbt = { version = "0.1.0", features = ["sifli", "prebuild"] }
 
 # TODO: multicore critical-section impl
 cortex-m = { version = "0.7.7" }
@@ -125,4 +123,3 @@ unchecked-overclocking = []
 
 [package.metadata.docs.rs]
 default-target = "thumbv8m.main-none-eabihf"
-

--- a/sifli-hal/src/lcpu/bt_rf_cal/consts.rs
+++ b/sifli-hal/src/lcpu/bt_rf_cal/consts.rs
@@ -1,0 +1,81 @@
+//! Shared constants for BT RF calibration algorithms.
+//!
+//! Constants used by both VCO 5GHz (vco.rs) and EDR LO 3GHz (edr_lo.rs) calibration.
+
+// ============================================================
+// IDAC / PDX (capcode) algorithm constants
+// ============================================================
+
+/// IDAC binary search initial value (7-bit midpoint).
+pub const IDAC_INITIAL: u8 = 0x40;
+
+/// IDAC binary search full-scale value.
+pub const IDAC_FS: u8 = 0x40;
+
+/// IDAC maximum value (7-bit: 0x3F = 63).
+pub const IDAC_MAX: u8 = 0x3F;
+
+/// PDX (capcode) binary search initial value (8-bit midpoint).
+pub const PDX_INITIAL: u8 = 0x80;
+
+/// PDX binary search full-scale value.
+pub const PDX_FS: u8 = 0x80;
+
+/// Maximum sweep steps for linear frequency scan.
+pub const MAX_LO_CAL_STEP: usize = 256;
+
+// ============================================================
+// VCO ACAL threshold pairs
+// ============================================================
+
+/// ACAL_VL_SEL during calibration (relaxed thresholds for sweep).
+pub const VCO_ACAL_VL_CAL: u8 = 0x1;
+
+/// ACAL_VH_SEL during calibration.
+pub const VCO_ACAL_VH_CAL: u8 = 0x3;
+
+/// ACAL_VL_SEL for normal operation (tight thresholds).
+pub const VCO_ACAL_VL_NORMAL: u8 = 0x5;
+
+/// ACAL_VH_SEL for normal operation.
+pub const VCO_ACAL_VH_NORMAL: u8 = 0x7;
+
+/// INCFCAL_VL_SEL for normal operation.
+pub const VCO_INCFCAL_VL: u8 = 0x2;
+
+/// INCFCAL_VH_SEL for normal operation.
+pub const VCO_INCFCAL_VH: u8 = 0x5;
+
+/// VCO LDO voltage reference setting.
+pub const VCO_LDO_VREF: u8 = 0xA;
+
+// ============================================================
+// PHY FCW (Frequency Control Word) values
+// ============================================================
+
+/// LFP_FCW value for calibration (PAC field is u16).
+pub const LFP_FCW_CAL: u16 = 0x08;
+
+/// HFP_FCW value for calibration (PAC field is u8).
+pub const HFP_FCW_CAL: u8 = 0x07;
+
+// ============================================================
+// FBDV modulator stage configuration
+// ============================================================
+
+/// FBDV modulator stage for 5GHz VCO (BLE).
+pub const FBDV_MOD_STG_5G: u8 = 2;
+
+/// FBDV modulator stage for 3GHz VCO (EDR).
+#[cfg(feature = "edr-cal")]
+pub const FBDV_MOD_STG_3G: u8 = 1;
+
+// ============================================================
+// Sequential ACAL termination thresholds
+// ============================================================
+
+/// Sequential ACAL: max direction-change count before termination.
+pub const SEQ_ACAL_JUMP_LIMIT: u8 = 4;
+
+/// Sequential ACAL: max full-scale (rail) count before termination.
+pub const SEQ_ACAL_FULL_LIMIT: u8 = 2;

--- a/sifli-hal/src/lcpu/bt_rf_cal/mod.rs
+++ b/sifli-hal/src/lcpu/bt_rf_cal/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! Based on SDK `bt_rf_cal()` and related functions in `bt_rf_fulcal.c`.
 
+mod consts;
 #[cfg(feature = "edr-cal")]
 mod edr_lo;
 mod opt;
@@ -26,6 +27,9 @@ use crate::Peripheral;
 
 /// RFC SRAM base address
 const BT_RFC_MEM_BASE: u32 = super::memory_map::rf::BT_RFC_MEM_BASE;
+
+/// RF driver version: v6.0.0.
+const RF_DRIVER_VERSION: u32 = 0x0006_0000;
 
 /// Default EDR PA BM values for each power level (0-7)
 ///
@@ -375,13 +379,13 @@ pub fn bt_rf_cal(dma_ch: impl Peripheral<P = impl Channel>) {
 
     // Restore VCO thresholds to normal mode after TXDC cal (SDK:4664-4673)
     BT_RFC.vco_reg2().modify(|w| {
-        w.set_brf_vco_acal_vl_sel_lv(0x5);
-        w.set_brf_vco_acal_vh_sel_lv(0x7);
-        w.set_brf_vco_incfcal_vl_sel_lv(0x2);
-        w.set_brf_vco_incfcal_vh_sel_lv(0x5);
+        w.set_brf_vco_acal_vl_sel_lv(consts::VCO_ACAL_VL_NORMAL);
+        w.set_brf_vco_acal_vh_sel_lv(consts::VCO_ACAL_VH_NORMAL);
+        w.set_brf_vco_incfcal_vl_sel_lv(consts::VCO_INCFCAL_VL);
+        w.set_brf_vco_incfcal_vh_sel_lv(consts::VCO_INCFCAL_VH);
     });
     BT_RFC.vco_reg1().modify(|w| {
-        w.set_brf_vco_ldo_vref_lv(0xA);
+        w.set_brf_vco_ldo_vref_lv(consts::VCO_LDO_VREF);
     });
     rf_dump_checkpoint("AFTER_TXDC_CAL");
 
@@ -389,8 +393,8 @@ pub fn bt_rf_cal(dma_ch: impl Peripheral<P = impl Channel>) {
     opt::bt_rf_opt_cal();
     rf_dump_checkpoint("AFTER_OPT_CAL");
 
-    // SDK:5481 — store driver version
-    vco::set_driver_version(0x00060000);
+    // SDK:5481 — store driver version (v6.0.0)
+    vco::set_driver_version(RF_DRIVER_VERSION);
 
     // TODO: BQB co-channel config (SDK:5482-5486, BR_BQB_COCHANNEL_CASE)
     //   DEMOD_CFG8 BR_DEMOD_G/MU_DC/MU_ERR, DEMOD_CFG16 BR_HADAPT_EN

--- a/sifli-hal/src/lcpu/bt_rf_cal/rfc_cmd.rs
+++ b/sifli-hal/src/lcpu/bt_rf_cal/rfc_cmd.rs
@@ -11,215 +11,129 @@
 //! Based on SDK `bt_rfc_init()` in `bt_rf_fulcal.c`.
 
 use crate::pac::BT_RFC;
-
-/// BT_RFC register byte offsets for the RFC command sequencer.
-mod reg {
-    pub const VCO_REG1: u16 = 0x00;
-    pub const VCO_REG2: u16 = 0x04;
-    pub const VCO_REG3: u16 = 0x08;
-    pub const RF_LODIST_REG: u16 = 0x10;
-    pub const FBDV_REG1: u16 = 0x14;
-    pub const PFDCP_REG: u16 = 0x1C;
-    pub const EDR_CAL_REG1: u16 = 0x24;
-    pub const OSLO_REG: u16 = 0x28;
-    pub const TRF_REG1: u16 = 0x34;
-    pub const TRF_REG2: u16 = 0x38;
-    pub const TRF_EDR_REG1: u16 = 0x3C;
-    pub const TRF_EDR_REG2: u16 = 0x40;
-    pub const RRF_REG: u16 = 0x44;
-    pub const RBB_REG1: u16 = 0x48;
-    pub const RBB_REG2: u16 = 0x4C;
-    pub const RBB_REG3: u16 = 0x50;
-    pub const RBB_REG5: u16 = 0x58;
-    pub const ADC_REG: u16 = 0x60;
-    pub const TBB_REG: u16 = 0x64;
-    pub const ATSTBUF_REG: u16 = 0x6C;
-    pub const INCCAL_REG1: u16 = 0x74;
-    pub const IQ_PWR_REG1: u16 = 0xA8;
-    pub const IQ_PWR_REG2: u16 = 0xAC;
-}
-
-// RFC command opcodes (16-bit instructions, two packed per 32-bit word)
-const fn rd(n: u16) -> u16 {
-    0x1800 + n
-}
-const fn wr(n: u16) -> u16 {
-    0x2800 + n
-}
-const fn and(n: u16) -> u16 {
-    0x3000 + n
-}
-const fn or(n: u16) -> u16 {
-    0x4000 + n
-}
-const fn wait(n: u16) -> u16 {
-    0x5000 + n
-}
-const RD_FULCAL: u16 = 0x6000;
-const RD_DCCAL1: u16 = 0x7000;
-const RD_DCCAL2: u16 = 0x8000;
-const END: u16 = 0xF000;
-
-/// Helper to build a command sequence in a fixed-size buffer.
-struct CmdBuilder {
-    buf: [u16; 128],
-    len: usize,
-}
-
-impl CmdBuilder {
-    const fn new() -> Self {
-        Self {
-            buf: [0; 128],
-            len: 0,
-        }
-    }
-
-    fn push(&mut self, cmd: u16) {
-        self.buf[self.len] = cmd;
-        self.len += 1;
-    }
-
-    /// Pad to even length (commands are packed as pairs into 32-bit words).
-    fn pad_even(&mut self) {
-        if !self.len.is_multiple_of(2) {
-            self.push(END);
-        }
-    }
-
-    /// Write the command sequence to RFC SRAM starting at `offset`.
-    /// Returns the next available offset (after the last written word).
-    fn write_to_sram(&self, offset: u32) -> u32 {
-        let base = super::BT_RFC_MEM_BASE;
-        let mut addr = offset;
-        for i in (0..self.len).step_by(2) {
-            let lo = self.buf[i] as u32;
-            let hi = self.buf[i + 1] as u32;
-            let word = lo | (hi << 16);
-            unsafe {
-                core::ptr::write_volatile((base + addr) as *mut u32, word);
-            }
-            addr += 4;
-        }
-        addr
-    }
-}
+use rwbt::rfc::cmd::{self, CmdBuilder};
+use rwbt::rfc::sifli::regs::{
+    adc_reg, fbdv_reg1, inccal_reg1, offset as reg, oslo_reg, pfdcp_reg, rbb_reg1, rbb_reg2,
+    rbb_reg3, rbb_reg5, rf_lodist_reg, rrf_reg, tbb_reg, trf_edr_reg1, trf_edr_reg2, trf_reg1,
+    trf_reg2, vco_reg1, vco_reg2,
+};
 
 /// Build the RXON command sequence (BLE RX startup).
 fn build_rxon() -> CmdBuilder {
     let mut c = CmdBuilder::new();
 
     // VDDPSW/RFBG_EN/LO_IARY_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(or(18));
-    c.push(or(17));
-    c.push(or(16));
-    c.push(wr(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::or(rf_lodist_reg::BRF_EN_VDDPSW_LV));
+    c.push(cmd::or(rf_lodist_reg::BRF_EN_RFBG_LV));
+    c.push(cmd::or(rf_lodist_reg::BRF_LO_IARY_EN_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
     // wait 1us
-    c.push(wait(2));
+    c.push(cmd::wait(2));
 
     // FULCAL RSLT
-    c.push(RD_FULCAL);
-    c.push(wr(reg::VCO_REG3));
+    c.push(cmd::RD_FULCAL);
+    c.push(cmd::wr(reg::VCO_REG3));
 
     // VCO5G_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(or(12));
-    c.push(wr(reg::VCO_REG1));
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::or(vco_reg1::BRF_VCO5G_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
     // PFDCP_EN
-    c.push(rd(reg::PFDCP_REG));
-    c.push(or(19));
-    c.push(wr(reg::PFDCP_REG));
+    c.push(cmd::rd(reg::PFDCP_REG));
+    c.push(cmd::or(pfdcp_reg::BRF_PFDCP_EN_LV));
+    c.push(cmd::wr(reg::PFDCP_REG));
 
     // FBDV_EN
-    c.push(rd(reg::FBDV_REG1));
-    c.push(or(12));
-    c.push(wr(reg::FBDV_REG1));
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_EN_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // FBDV_RSTB
-    c.push(rd(reg::FBDV_REG1));
-    c.push(and(0x7));
-    c.push(wr(reg::FBDV_REG1));
+    // FBDV_RSTB (clear bit 7)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_RSTB_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
     // wait 30us for LO lock
-    c.push(wait(45));
+    c.push(cmd::wait(45));
 
     // VCO_FLT_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(or(7));
-    c.push(wr(reg::VCO_REG1));
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::or(vco_reg1::BRF_VCO_FLT_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
-    // LDO11_EN & LNA_SHUNTSW
-    c.push(rd(reg::RRF_REG));
-    c.push(or(22));
-    c.push(and(6));
-    c.push(wr(reg::RRF_REG));
+    // LDO11_EN & LNA_SHUNTSW (clear)
+    c.push(cmd::rd(reg::RRF_REG));
+    c.push(cmd::or(rrf_reg::BRF_RRF_LDO11_EN_LV));
+    c.push(cmd::and(rrf_reg::BRF_LNA_SHUNTSW_LV));
+    c.push(cmd::wr(reg::RRF_REG));
 
-    // ADC & LDO_ADC & LDO_ADCREF
-    c.push(rd(reg::ADC_REG));
-    c.push(or(4));
-    c.push(or(9));
-    c.push(or(21));
-    c.push(or(20));
-    c.push(wr(reg::ADC_REG));
+    // ADC: LDO_ADCREF, LDO_ADC, ADC_I, ADC_Q
+    c.push(cmd::rd(reg::ADC_REG));
+    c.push(cmd::or(adc_reg::BRF_EN_LDO_ADCREF_LV));
+    c.push(cmd::or(adc_reg::BRF_EN_LDO_ADC_LV));
+    c.push(cmd::or(adc_reg::BRF_EN_ADC_I_LV));
+    c.push(cmd::or(adc_reg::BRF_EN_ADC_Q_LV));
+    c.push(cmd::wr(reg::ADC_REG));
 
     // LDO_RBB
-    c.push(rd(reg::RBB_REG1));
-    c.push(or(13));
-    c.push(wr(reg::RBB_REG1));
+    c.push(cmd::rd(reg::RBB_REG1));
+    c.push(cmd::or(rbb_reg1::BRF_EN_LDO_RBB_LV));
+    c.push(cmd::wr(reg::RBB_REG1));
 
-    // PA_TX_RX
-    c.push(rd(reg::TRF_REG2));
-    c.push(and(9));
-    c.push(wr(reg::TRF_REG2));
+    // PA_TX_RX (clear — set to RX mode)
+    c.push(cmd::rd(reg::TRF_REG2));
+    c.push(cmd::and(trf_reg2::BRF_PA_TX_RX_LV));
+    c.push(cmd::wr(reg::TRF_REG2));
 
-    // EN_IARRAY & EN_OSDAC
-    c.push(rd(reg::RBB_REG5));
-    c.push(or(5));
-    c.push(or(6));
-    c.push(or(7));
-    c.push(wr(reg::RBB_REG5));
+    // EN_IARRAY & EN_OSDACQ & EN_OSDACI
+    c.push(cmd::rd(reg::RBB_REG5));
+    c.push(cmd::or(rbb_reg5::BRF_EN_IARRAY_LV));
+    c.push(cmd::or(rbb_reg5::BRF_EN_OSDACQ_LV));
+    c.push(cmd::or(rbb_reg5::BRF_EN_OSDACI_LV));
+    c.push(cmd::wr(reg::RBB_REG5));
 
-    // EN_CBPF & EN_RVGA
-    c.push(rd(reg::RBB_REG2));
-    c.push(or(27));
-    c.push(or(6));
-    c.push(or(7));
-    c.push(wr(reg::RBB_REG2));
+    // EN_CBPF & EN_RVGA_Q & EN_RVGA_I
+    c.push(cmd::rd(reg::RBB_REG2));
+    c.push(cmd::or(rbb_reg2::BRF_EN_CBPF_LV));
+    c.push(cmd::or(rbb_reg2::BRF_EN_RVGA_Q_LV));
+    c.push(cmd::or(rbb_reg2::BRF_EN_RVGA_I_LV));
+    c.push(cmd::wr(reg::RBB_REG2));
 
-    // EN_PKDET
-    c.push(rd(reg::RBB_REG3));
-    c.push(or(0));
-    c.push(or(1));
-    c.push(or(2));
-    c.push(or(3));
-    c.push(wr(reg::RBB_REG3));
+    // EN_PKDET (4-bit field, set bits 0-3 individually)
+    c.push(cmd::rd(reg::RBB_REG3));
+    c.push(cmd::or(rbb_reg3::BRF_EN_PKDET_LV));
+    c.push(cmd::or(rbb_reg3::BRF_EN_PKDET_LV + 1));
+    c.push(cmd::or(rbb_reg3::BRF_EN_PKDET_LV + 2));
+    c.push(cmd::or(rbb_reg3::BRF_EN_PKDET_LV + 3));
+    c.push(cmd::wr(reg::RBB_REG3));
 
     // wait 4us
-    c.push(wait(5));
+    c.push(cmd::wait(5));
 
     // LODIST5G_RX_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(or(9));
-    c.push(wr(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::or(rf_lodist_reg::BRF_LODIST5G_RX_EN_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
     // LNA_PU & MX_PU
-    c.push(rd(reg::RRF_REG));
-    c.push(or(3));
-    c.push(or(17));
-    c.push(wr(reg::RRF_REG));
+    c.push(cmd::rd(reg::RRF_REG));
+    c.push(cmd::or(rrf_reg::BRF_MX_PU_LV));
+    c.push(cmd::or(rrf_reg::BRF_LNA_PU_LV));
+    c.push(cmd::wr(reg::RRF_REG));
 
     // START INCCAL
-    c.push(rd(reg::INCCAL_REG1));
-    c.push(or(29));
-    c.push(wr(reg::INCCAL_REG1));
+    c.push(cmd::rd(reg::INCCAL_REG1));
+    c.push(cmd::or(inccal_reg1::INCCAL_START));
+    c.push(cmd::wr(reg::INCCAL_REG1));
 
-    c.push(wait(30));
+    c.push(cmd::wait(30));
 
     // END
-    c.push(END);
+    c.push(cmd::END);
     c.pad_even();
     c
 }
@@ -228,82 +142,82 @@ fn build_rxon() -> CmdBuilder {
 fn build_rxoff() -> CmdBuilder {
     let mut c = CmdBuilder::new();
 
-    // VDDPSW/RFBG/LODIST5G_RX_EN/LO_IARY_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(and(18));
-    c.push(and(17));
-    c.push(and(16));
-    c.push(and(9));
-    c.push(wr(reg::RF_LODIST_REG));
+    // VDDPSW/RFBG/LODIST5G_RX_EN/LO_IARY_EN (clear all)
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::and(rf_lodist_reg::BRF_EN_VDDPSW_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_EN_RFBG_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_LO_IARY_EN_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_LODIST5G_RX_EN_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
-    // VCO5G_EN & VCO_FLT_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(and(12));
-    c.push(and(7));
-    c.push(wr(reg::VCO_REG1));
+    // VCO5G_EN & VCO_FLT_EN (clear)
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::and(vco_reg1::BRF_VCO5G_EN_LV));
+    c.push(cmd::and(vco_reg1::BRF_VCO_FLT_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
-    // FBDV_EN / FBDV_RSTB
-    c.push(rd(reg::FBDV_REG1));
-    c.push(and(12));
-    c.push(or(0x7));
-    c.push(wr(reg::FBDV_REG1));
+    // FBDV_EN (clear) / FBDV_RSTB (set)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_EN_LV));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_RSTB_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // PFDCP_EN
-    c.push(rd(reg::PFDCP_REG));
-    c.push(and(19));
-    c.push(wr(reg::PFDCP_REG));
+    // PFDCP_EN (clear)
+    c.push(cmd::rd(reg::PFDCP_REG));
+    c.push(cmd::and(pfdcp_reg::BRF_PFDCP_EN_LV));
+    c.push(cmd::wr(reg::PFDCP_REG));
 
-    // LNA_PU & MX_PU & LDO11_EN & LNA_SHUNTSW
-    c.push(rd(reg::RRF_REG));
-    c.push(and(3));
-    c.push(or(6));
-    c.push(and(17));
-    c.push(and(22));
-    c.push(wr(reg::RRF_REG));
+    // LNA_PU & MX_PU (clear) & LDO11_EN (clear) & LNA_SHUNTSW (set)
+    c.push(cmd::rd(reg::RRF_REG));
+    c.push(cmd::and(rrf_reg::BRF_MX_PU_LV));
+    c.push(cmd::or(rrf_reg::BRF_LNA_SHUNTSW_LV));
+    c.push(cmd::and(rrf_reg::BRF_LNA_PU_LV));
+    c.push(cmd::and(rrf_reg::BRF_RRF_LDO11_EN_LV));
+    c.push(cmd::wr(reg::RRF_REG));
 
-    // ADC & LDO_ADC & LDO_ADCREF
-    c.push(rd(reg::ADC_REG));
-    c.push(and(4));
-    c.push(and(9));
-    c.push(and(21));
-    c.push(and(20));
-    c.push(wr(reg::ADC_REG));
+    // ADC: clear LDO_ADCREF, LDO_ADC, ADC_I, ADC_Q
+    c.push(cmd::rd(reg::ADC_REG));
+    c.push(cmd::and(adc_reg::BRF_EN_LDO_ADCREF_LV));
+    c.push(cmd::and(adc_reg::BRF_EN_LDO_ADC_LV));
+    c.push(cmd::and(adc_reg::BRF_EN_ADC_I_LV));
+    c.push(cmd::and(adc_reg::BRF_EN_ADC_Q_LV));
+    c.push(cmd::wr(reg::ADC_REG));
 
-    // LDO_RBB
-    c.push(rd(reg::RBB_REG1));
-    c.push(and(13));
-    c.push(wr(reg::RBB_REG1));
+    // LDO_RBB (clear)
+    c.push(cmd::rd(reg::RBB_REG1));
+    c.push(cmd::and(rbb_reg1::BRF_EN_LDO_RBB_LV));
+    c.push(cmd::wr(reg::RBB_REG1));
 
-    // PA_TX_RX
-    c.push(rd(reg::TRF_REG2));
-    c.push(or(9));
-    c.push(wr(reg::TRF_REG2));
+    // PA_TX_RX (set — back to TX mode)
+    c.push(cmd::rd(reg::TRF_REG2));
+    c.push(cmd::or(trf_reg2::BRF_PA_TX_RX_LV));
+    c.push(cmd::wr(reg::TRF_REG2));
 
-    // EN_IARRAY & EN_OSDAC
-    c.push(rd(reg::RBB_REG5));
-    c.push(and(5));
-    c.push(and(6));
-    c.push(and(7));
-    c.push(wr(reg::RBB_REG5));
+    // EN_IARRAY & EN_OSDACQ & EN_OSDACI (clear)
+    c.push(cmd::rd(reg::RBB_REG5));
+    c.push(cmd::and(rbb_reg5::BRF_EN_IARRAY_LV));
+    c.push(cmd::and(rbb_reg5::BRF_EN_OSDACQ_LV));
+    c.push(cmd::and(rbb_reg5::BRF_EN_OSDACI_LV));
+    c.push(cmd::wr(reg::RBB_REG5));
 
-    // EN_CBPF & EN_RVGA
-    c.push(rd(reg::RBB_REG2));
-    c.push(and(27));
-    c.push(and(6));
-    c.push(and(7));
-    c.push(wr(reg::RBB_REG2));
+    // EN_CBPF & EN_RVGA_Q & EN_RVGA_I (clear)
+    c.push(cmd::rd(reg::RBB_REG2));
+    c.push(cmd::and(rbb_reg2::BRF_EN_CBPF_LV));
+    c.push(cmd::and(rbb_reg2::BRF_EN_RVGA_Q_LV));
+    c.push(cmd::and(rbb_reg2::BRF_EN_RVGA_I_LV));
+    c.push(cmd::wr(reg::RBB_REG2));
 
-    // EN_PKDET
-    c.push(rd(reg::RBB_REG3));
-    c.push(and(0));
-    c.push(and(1));
-    c.push(and(2));
-    c.push(and(3));
-    c.push(wr(reg::RBB_REG3));
+    // EN_PKDET (clear bits 0-3)
+    c.push(cmd::rd(reg::RBB_REG3));
+    c.push(cmd::and(rbb_reg3::BRF_EN_PKDET_LV));
+    c.push(cmd::and(rbb_reg3::BRF_EN_PKDET_LV + 1));
+    c.push(cmd::and(rbb_reg3::BRF_EN_PKDET_LV + 2));
+    c.push(cmd::and(rbb_reg3::BRF_EN_PKDET_LV + 3));
+    c.push(cmd::wr(reg::RBB_REG3));
 
     // END
-    c.push(END);
+    c.push(cmd::END);
     c.pad_even();
     c
 }
@@ -313,85 +227,85 @@ fn build_txon() -> CmdBuilder {
     let mut c = CmdBuilder::new();
 
     // VDDPSW/RFBG_EN/LO_IARY_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(or(17));
-    c.push(or(18));
-    c.push(or(16));
-    c.push(wr(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::or(rf_lodist_reg::BRF_EN_RFBG_LV));
+    c.push(cmd::or(rf_lodist_reg::BRF_EN_VDDPSW_LV));
+    c.push(cmd::or(rf_lodist_reg::BRF_LO_IARY_EN_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
     // wait 1us
-    c.push(wait(2));
+    c.push(cmd::wait(2));
 
     // RD FULCAL
-    c.push(RD_FULCAL);
-    c.push(wr(reg::VCO_REG3));
+    c.push(cmd::RD_FULCAL);
+    c.push(cmd::wr(reg::VCO_REG3));
 
     // VCO5G_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(or(12));
-    c.push(wr(reg::VCO_REG1));
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::or(vco_reg1::BRF_VCO5G_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
     // FBDV_EN
-    c.push(rd(reg::FBDV_REG1));
-    c.push(or(12));
-    c.push(wr(reg::FBDV_REG1));
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_EN_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
     // PFDCP_EN
-    c.push(rd(reg::PFDCP_REG));
-    c.push(or(19));
-    c.push(wr(reg::PFDCP_REG));
+    c.push(cmd::rd(reg::PFDCP_REG));
+    c.push(cmd::or(pfdcp_reg::BRF_PFDCP_EN_LV));
+    c.push(cmd::wr(reg::PFDCP_REG));
 
-    // FBDV_RSTB
-    c.push(rd(reg::FBDV_REG1));
-    c.push(and(0x7));
-    c.push(wr(reg::FBDV_REG1));
+    // FBDV_RSTB (clear)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_RSTB_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
     // wait 30us for LO lock
-    c.push(wait(30));
+    c.push(cmd::wait(30));
 
     // VCO_FLT_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(or(7));
-    c.push(wr(reg::VCO_REG1));
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::or(vco_reg1::BRF_VCO_FLT_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
     // LODIST5G_BLETX_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(or(8));
-    c.push(wr(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::or(rf_lodist_reg::BRF_LODIST5G_BLETX_EN_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
     // EDR_IARRAY_EN
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(or(20));
-    c.push(wr(reg::TRF_EDR_REG1));
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::or(trf_edr_reg1::BRF_TRF_EDR_IARRAY_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG1));
 
     // PA_BUF_PU for normal TX
-    c.push(rd(reg::TRF_REG1));
-    c.push(or(22));
-    c.push(wr(reg::TRF_REG1));
+    c.push(cmd::rd(reg::TRF_REG1));
+    c.push(cmd::or(trf_reg1::BRF_PA_BUF_PU_LV));
+    c.push(cmd::wr(reg::TRF_REG1));
 
-    // EDR_XFMR_SG
-    c.push(rd(reg::TRF_EDR_REG2));
-    c.push(and(11));
-    c.push(wr(reg::TRF_EDR_REG2));
+    // EDR_XFMR_SG (clear)
+    c.push(cmd::rd(reg::TRF_EDR_REG2));
+    c.push(cmd::and(trf_edr_reg2::BRF_TRF_EDR_PA_XFMR_SG_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG2));
 
     // wait 4us
-    c.push(wait(5));
+    c.push(cmd::wait(5));
 
     // PA_OUT_PU & TRF_SIG_EN
-    c.push(rd(reg::TRF_REG1));
-    c.push(or(16));
-    c.push(or(21));
-    c.push(wr(reg::TRF_REG1));
+    c.push(cmd::rd(reg::TRF_REG1));
+    c.push(cmd::or(trf_reg1::BRF_TRF_SIG_EN_LV));
+    c.push(cmd::or(trf_reg1::BRF_PA_OUT_PU_LV));
+    c.push(cmd::wr(reg::TRF_REG1));
 
     // START INCCAL
-    c.push(rd(reg::INCCAL_REG1));
-    c.push(or(29));
-    c.push(wr(reg::INCCAL_REG1));
-    c.push(wait(9));
+    c.push(cmd::rd(reg::INCCAL_REG1));
+    c.push(cmd::or(inccal_reg1::INCCAL_START));
+    c.push(cmd::wr(reg::INCCAL_REG1));
+    c.push(cmd::wait(9));
 
     // END
-    c.push(END);
+    c.push(cmd::END);
     c.pad_even();
     c
 }
@@ -400,122 +314,122 @@ fn build_txon() -> CmdBuilder {
 fn build_txoff() -> CmdBuilder {
     let mut c = CmdBuilder::new();
 
-    // VDDPSW/RFBG_EN/LO_IARY_EN/LODIST5G_BLETX_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(and(8));
-    c.push(and(16));
-    c.push(and(17));
-    c.push(and(18));
-    c.push(wr(reg::RF_LODIST_REG));
+    // VDDPSW/RFBG_EN/LO_IARY_EN/LODIST5G_BLETX_EN (clear all)
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::and(rf_lodist_reg::BRF_LODIST5G_BLETX_EN_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_LO_IARY_EN_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_EN_RFBG_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_EN_VDDPSW_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
-    // VCO5G_EN & VCO_FLT_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(and(12));
-    c.push(and(7));
-    c.push(wr(reg::VCO_REG1));
+    // VCO5G_EN & VCO_FLT_EN (clear)
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::and(vco_reg1::BRF_VCO5G_EN_LV));
+    c.push(cmd::and(vco_reg1::BRF_VCO_FLT_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
-    // FBDV_EN / FBDV_RSTB
-    c.push(rd(reg::FBDV_REG1));
-    c.push(and(12));
-    c.push(or(0x7));
-    c.push(wr(reg::FBDV_REG1));
+    // FBDV_EN (clear) / FBDV_RSTB (set)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_EN_LV));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_RSTB_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // PFDCP_EN
-    c.push(rd(reg::PFDCP_REG));
-    c.push(and(19));
-    c.push(wr(reg::PFDCP_REG));
+    // PFDCP_EN (clear)
+    c.push(cmd::rd(reg::PFDCP_REG));
+    c.push(cmd::and(pfdcp_reg::BRF_PFDCP_EN_LV));
+    c.push(cmd::wr(reg::PFDCP_REG));
 
-    // PA_BUF_PU & PA_OUT_PU & TRF_SIG_EN
-    c.push(rd(reg::TRF_REG1));
-    c.push(and(22));
-    c.push(and(16));
-    c.push(and(21));
-    c.push(wr(reg::TRF_REG1));
+    // PA_BUF_PU & PA_OUT_PU & TRF_SIG_EN (clear)
+    c.push(cmd::rd(reg::TRF_REG1));
+    c.push(cmd::and(trf_reg1::BRF_PA_BUF_PU_LV));
+    c.push(cmd::and(trf_reg1::BRF_TRF_SIG_EN_LV));
+    c.push(cmd::and(trf_reg1::BRF_PA_OUT_PU_LV));
+    c.push(cmd::wr(reg::TRF_REG1));
 
-    // TRF_EDR_IARRAY_EN
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(and(20));
-    c.push(wr(reg::TRF_EDR_REG1));
+    // TRF_EDR_IARRAY_EN (clear)
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::and(trf_edr_reg1::BRF_TRF_EDR_IARRAY_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG1));
 
     // Redundancy from bt_txoff:
-    // DAC_STOP / EN_TBB_IARRY & EN_LDO_DAC_AVDD & EN_LDO_DAC_DVDD & EN_DAC
-    c.push(rd(reg::TBB_REG));
-    c.push(and(8));
-    c.push(and(9));
-    c.push(and(10));
-    c.push(and(11));
-    c.push(and(12));
-    c.push(wr(reg::TBB_REG));
+    // DAC_STOP / EN_TBB_IARRY & EN_LDO_DAC_AVDD & EN_LDO_DAC_DVDD & EN_DAC (clear)
+    c.push(cmd::rd(reg::TBB_REG));
+    c.push(cmd::and(tbb_reg::BRF_EN_TBB_IARRAY_LV));
+    c.push(cmd::and(tbb_reg::BRF_EN_LDO_DAC_DVDD_LV));
+    c.push(cmd::and(tbb_reg::BRF_EN_LDO_DAC_AVDD_LV));
+    c.push(cmd::and(tbb_reg::BRF_EN_DAC_LV));
+    c.push(cmd::and(tbb_reg::BRF_DAC_START_LV));
+    c.push(cmd::wr(reg::TBB_REG));
 
-    // EDR_PACAP_EN & EDR_PA_XFMR_SG
-    c.push(rd(reg::TRF_EDR_REG2));
-    c.push(and(11));
-    c.push(and(17));
-    c.push(wr(reg::TRF_EDR_REG2));
+    // EDR_PACAP_EN & EDR_PA_XFMR_SG (clear)
+    c.push(cmd::rd(reg::TRF_EDR_REG2));
+    c.push(cmd::and(trf_edr_reg2::BRF_TRF_EDR_PA_XFMR_SG_LV));
+    c.push(cmd::and(trf_edr_reg2::BRF_TRF_EDR_PACAP_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG2));
 
-    // TRF_EDR_IARRAY_EN
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(and(2));
-    c.push(and(12));
-    c.push(and(19));
-    c.push(wr(reg::TRF_EDR_REG1));
+    // TRF_EDR: PA_PU, TMX_PU, TMXBUF_PU (clear)
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::and(trf_edr_reg1::BRF_TRF_EDR_PA_PU_LV));
+    c.push(cmd::and(trf_edr_reg1::BRF_TRF_EDR_TMX_PU_LV));
+    c.push(cmd::and(trf_edr_reg1::BRF_TRF_EDR_TMXBUF_PU_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG1));
 
-    // EDR_EN_OSLO
-    c.push(rd(reg::OSLO_REG));
-    c.push(and(11));
-    c.push(wr(reg::OSLO_REG));
+    // EDR_EN_OSLO (clear)
+    c.push(cmd::rd(reg::OSLO_REG));
+    c.push(cmd::and(oslo_reg::BRF_OSLO_EN_LV));
+    c.push(cmd::wr(reg::OSLO_REG));
 
-    // VCO3G_EN/EDR_VCO_FLT_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(and(13));
-    c.push(and(7));
-    c.push(wr(reg::VCO_REG1));
+    // VCO3G_EN/EDR_VCO_FLT_EN (clear)
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::and(vco_reg1::BRF_VCO3G_EN_LV));
+    c.push(cmd::and(vco_reg1::BRF_VCO_FLT_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
-    // EDR_FBDV_RSTB
-    c.push(rd(reg::FBDV_REG1));
-    c.push(or(7));
-    c.push(wr(reg::FBDV_REG1));
+    // EDR_FBDV_RSTB (set)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_RSTB_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // EDR PFDCP_EN
-    c.push(rd(reg::PFDCP_REG));
-    c.push(and(19));
-    c.push(wr(reg::PFDCP_REG));
+    // EDR PFDCP_EN (clear)
+    c.push(cmd::rd(reg::PFDCP_REG));
+    c.push(cmd::and(pfdcp_reg::BRF_PFDCP_EN_LV));
+    c.push(cmd::wr(reg::PFDCP_REG));
 
-    // EDR FBDV_EN/MOD_STG/SDM_CLK_SEL
-    c.push(rd(reg::FBDV_REG1));
-    c.push(and(12));
-    c.push(or(5));
-    c.push(and(4));
-    c.push(or(3));
-    c.push(wr(reg::FBDV_REG1));
+    // EDR FBDV_EN(clear)/MOD_STG(set bit5)/SDM_CLK_SEL(clear bit4, set bit3)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_EN_LV));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_MOD_STG_LV + 1)); // bit 5
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_MOD_STG_LV));     // bit 4
+    c.push(cmd::or(fbdv_reg1::BRF_SDM_CLK_SEL_LV));       // bit 3
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // ACAL_VH_SEL=3/ACAL_VL_SEL=1
-    c.push(rd(reg::VCO_REG2));
-    c.push(and(2));
-    c.push(and(6));
-    c.push(wr(reg::VCO_REG2));
+    // ACAL_VH_SEL=3/ACAL_VL_SEL=1 (clear bit2, clear bit6)
+    c.push(cmd::rd(reg::VCO_REG2));
+    c.push(cmd::and(vco_reg2::BRF_VCO_ACAL_VL_SEL_LV + 2)); // bit 2
+    c.push(cmd::and(vco_reg2::BRF_VCO_ACAL_VH_SEL_LV + 2)); // bit 6
+    c.push(cmd::wr(reg::VCO_REG2));
 
-    // LDO_RBB
-    c.push(rd(reg::RBB_REG1));
-    c.push(and(13));
-    c.push(wr(reg::RBB_REG1));
+    // LDO_RBB (clear)
+    c.push(cmd::rd(reg::RBB_REG1));
+    c.push(cmd::and(rbb_reg1::BRF_EN_LDO_RBB_LV));
+    c.push(cmd::wr(reg::RBB_REG1));
 
-    // EDR VCO3G_EN/EDR_VCO5G_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(and(13));
-    c.push(wr(reg::EDR_CAL_REG1));
+    // EDR VCO3G_EN (clear) → write to EDR_CAL_REG1
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::and(vco_reg1::BRF_VCO3G_EN_LV));
+    c.push(cmd::wr(reg::EDR_CAL_REG1));
 
-    // VDDPSW/RFBG_EN/LO_IARY_EN/LODISTEDR_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(and(0));
-    c.push(and(16));
-    c.push(and(17));
-    c.push(and(18));
-    c.push(wr(reg::RF_LODIST_REG));
+    // VDDPSW/RFBG_EN/LO_IARY_EN/LODISTEDR_EN (clear)
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::and(rf_lodist_reg::BRF_LODISTEDR_EN_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_LO_IARY_EN_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_EN_RFBG_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_EN_VDDPSW_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
     // END
-    c.push(END);
+    c.push(cmd::END);
     c.pad_even();
     c
 }
@@ -525,157 +439,157 @@ fn build_bt_txon() -> CmdBuilder {
     let mut c = CmdBuilder::new();
 
     // VDDPSW/RFBG_EN/LO_IARY_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(or(16));
-    c.push(or(17));
-    c.push(or(18));
-    c.push(wr(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::or(rf_lodist_reg::BRF_LO_IARY_EN_LV));
+    c.push(cmd::or(rf_lodist_reg::BRF_EN_RFBG_LV));
+    c.push(cmd::or(rf_lodist_reg::BRF_EN_VDDPSW_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
     // wait 1us
-    c.push(wait(2));
+    c.push(cmd::wait(2));
 
     // LDO_RBB
-    c.push(rd(reg::RBB_REG1));
-    c.push(or(13));
-    c.push(wr(reg::RBB_REG1));
+    c.push(cmd::rd(reg::RBB_REG1));
+    c.push(cmd::or(rbb_reg1::BRF_EN_LDO_RBB_LV));
+    c.push(cmd::wr(reg::RBB_REG1));
 
-    // RD FULCAL
-    c.push(RD_FULCAL);
-    c.push(wr(reg::EDR_CAL_REG1));
-    c.push(wr(reg::ATSTBUF_REG));
+    // RD FULCAL → write to EDR_CAL_REG1 and ATSTBUF_REG
+    c.push(cmd::RD_FULCAL);
+    c.push(cmd::wr(reg::EDR_CAL_REG1));
+    c.push(cmd::wr(reg::ATSTBUF_REG));
 
     // VCO3G_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(or(13));
-    c.push(wr(reg::VCO_REG1));
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::or(vco_reg1::BRF_VCO3G_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
-    // PFDCP_EN ICP_SET
-    c.push(rd(reg::PFDCP_REG));
-    c.push(or(19));
-    c.push(or(11));
-    c.push(and(13));
-    c.push(wr(reg::PFDCP_REG));
+    // PFDCP_EN, ICP_SET (set bit 11, clear bit 13)
+    c.push(cmd::rd(reg::PFDCP_REG));
+    c.push(cmd::or(pfdcp_reg::BRF_PFDCP_EN_LV));
+    c.push(cmd::or(pfdcp_reg::BRF_PFDCP_ICP_SET_LV));      // bit 11
+    c.push(cmd::and(pfdcp_reg::BRF_PFDCP_ICP_SET_LV + 2));  // bit 13
+    c.push(cmd::wr(reg::PFDCP_REG));
 
-    // FBDV_EN/MOD_STG/SDM_CLK_SEL
-    c.push(rd(reg::FBDV_REG1));
-    c.push(or(12));
-    c.push(and(5));
-    c.push(or(4));
-    c.push(and(3));
-    c.push(wr(reg::FBDV_REG1));
+    // FBDV_EN/MOD_STG/SDM_CLK_SEL (3G mode: MOD_STG=1, SDM_CLK_SEL=0)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_EN_LV));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_MOD_STG_LV + 1));  // bit 5
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_MOD_STG_LV));       // bit 4
+    c.push(cmd::and(fbdv_reg1::BRF_SDM_CLK_SEL_LV));        // bit 3
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // FBDV_RSTB
-    c.push(rd(reg::FBDV_REG1));
-    c.push(and(7));
-    c.push(wr(reg::FBDV_REG1));
+    // FBDV_RSTB (clear)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_RSTB_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // ACAL_VH_SEL=7/ACAL_VL_SEL=5
-    c.push(rd(reg::VCO_REG2));
-    c.push(or(2));
-    c.push(or(6));
-    c.push(wr(reg::VCO_REG2));
+    // ACAL_VH_SEL=7/ACAL_VL_SEL=5 (set bit 2, set bit 6)
+    c.push(cmd::rd(reg::VCO_REG2));
+    c.push(cmd::or(vco_reg2::BRF_VCO_ACAL_VL_SEL_LV + 2));  // bit 2
+    c.push(cmd::or(vco_reg2::BRF_VCO_ACAL_VH_SEL_LV + 2));  // bit 6
+    c.push(cmd::wr(reg::VCO_REG2));
 
     // EDR_VCO_FLT_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(or(7));
-    c.push(wr(reg::VCO_REG1));
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::or(vco_reg1::BRF_VCO_FLT_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
     // EDR_EN_OSLO
-    c.push(rd(reg::OSLO_REG));
-    c.push(or(11));
-    c.push(wr(reg::OSLO_REG));
+    c.push(cmd::rd(reg::OSLO_REG));
+    c.push(cmd::or(oslo_reg::BRF_OSLO_EN_LV));
+    c.push(cmd::wr(reg::OSLO_REG));
 
     // LODISTEDR_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(or(0));
-    c.push(wr(reg::RF_LODIST_REG));
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::or(rf_lodist_reg::BRF_LODISTEDR_EN_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
     // EN_TBB_IARRY & EN_LDO_DAC_AVDD & EN_LDO_DAC_DVDD & EN_DAC
-    c.push(rd(reg::TBB_REG));
-    c.push(or(8));
-    c.push(or(9));
-    c.push(or(10));
-    c.push(or(11));
-    c.push(wr(reg::TBB_REG));
+    c.push(cmd::rd(reg::TBB_REG));
+    c.push(cmd::or(tbb_reg::BRF_EN_TBB_IARRAY_LV));
+    c.push(cmd::or(tbb_reg::BRF_EN_LDO_DAC_DVDD_LV));
+    c.push(cmd::or(tbb_reg::BRF_EN_LDO_DAC_AVDD_LV));
+    c.push(cmd::or(tbb_reg::BRF_EN_DAC_LV));
+    c.push(cmd::wr(reg::TBB_REG));
 
     // TRF_EDR_IARRAY_EN
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(or(20));
-    c.push(wr(reg::TRF_EDR_REG1));
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::or(trf_edr_reg1::BRF_TRF_EDR_IARRAY_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG1));
 
     // EDR_PACAP_EN & EDR_PA_XFMR_SG
-    c.push(rd(reg::TRF_EDR_REG2));
-    c.push(or(11));
-    c.push(or(17));
-    c.push(wr(reg::TRF_EDR_REG2));
+    c.push(cmd::rd(reg::TRF_EDR_REG2));
+    c.push(cmd::or(trf_edr_reg2::BRF_TRF_EDR_PA_XFMR_SG_LV));
+    c.push(cmd::or(trf_edr_reg2::BRF_TRF_EDR_PACAP_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG2));
 
     // RD DCCAL
-    c.push(RD_DCCAL1);
-    c.push(wr(reg::IQ_PWR_REG1));
-    c.push(RD_DCCAL2);
-    c.push(wr(reg::IQ_PWR_REG2));
+    c.push(cmd::RD_DCCAL1);
+    c.push(cmd::wr(reg::IQ_PWR_REG1));
+    c.push(cmd::RD_DCCAL2);
+    c.push(cmd::wr(reg::IQ_PWR_REG2));
 
     // EDR_TMXBUF_PU EDR_TMX_PU
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(or(12));
-    c.push(or(19));
-    c.push(wr(reg::TRF_EDR_REG1));
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::or(trf_edr_reg1::BRF_TRF_EDR_TMX_PU_LV));
+    c.push(cmd::or(trf_edr_reg1::BRF_TRF_EDR_TMXBUF_PU_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG1));
 
     // cmd for cal: RBB_REG5 EN_IARRAY
-    c.push(rd(reg::RBB_REG5));
-    c.push(or(5));
-    c.push(wr(reg::RBB_REG5));
+    c.push(cmd::rd(reg::RBB_REG5));
+    c.push(cmd::or(rbb_reg5::BRF_EN_IARRAY_LV));
+    c.push(cmd::wr(reg::RBB_REG5));
 
     // EN_RVGA_I
-    c.push(rd(reg::RBB_REG2));
-    c.push(or(7));
-    c.push(wr(reg::RBB_REG2));
+    c.push(cmd::rd(reg::RBB_REG2));
+    c.push(cmd::or(rbb_reg2::BRF_EN_RVGA_I_LV));
+    c.push(cmd::wr(reg::RBB_REG2));
 
-    // ADC & LDO_ADC & LDO_ADCREF
-    c.push(rd(reg::ADC_REG));
-    c.push(or(4));
-    c.push(or(9));
-    c.push(or(21));
-    c.push(wr(reg::ADC_REG));
+    // ADC: LDO_ADCREF, LDO_ADC, ADC_I
+    c.push(cmd::rd(reg::ADC_REG));
+    c.push(cmd::or(adc_reg::BRF_EN_LDO_ADCREF_LV));
+    c.push(cmd::or(adc_reg::BRF_EN_LDO_ADC_LV));
+    c.push(cmd::or(adc_reg::BRF_EN_ADC_I_LV));
+    c.push(cmd::wr(reg::ADC_REG));
 
     // wait 5us
-    c.push(wait(8));
+    c.push(cmd::wait(8));
 
     // pwrmtr_en
-    c.push(rd(reg::TRF_EDR_REG2));
-    c.push(or(10));
-    c.push(wr(reg::TRF_EDR_REG2));
+    c.push(cmd::rd(reg::TRF_EDR_REG2));
+    c.push(cmd::or(trf_edr_reg2::BRF_TRF_EDR_PWRMTR_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG2));
 
     // wait 3us
-    c.push(wait(5));
+    c.push(cmd::wait(5));
 
     // lpbk en
-    c.push(rd(reg::RBB_REG5));
-    c.push(or(0));
-    c.push(wr(reg::RBB_REG5));
+    c.push(cmd::rd(reg::RBB_REG5));
+    c.push(cmd::or(rbb_reg5::BRF_RVGA_TX_LPBK_EN_LV));
+    c.push(cmd::wr(reg::RBB_REG5));
 
     // wait 30us for LO lock
-    c.push(wait(20));
+    c.push(cmd::wait(20));
 
     // START INCCAL
-    c.push(rd(reg::INCCAL_REG1));
-    c.push(or(29));
-    c.push(wr(reg::INCCAL_REG1));
-    c.push(wait(9));
+    c.push(cmd::rd(reg::INCCAL_REG1));
+    c.push(cmd::or(inccal_reg1::INCCAL_START));
+    c.push(cmd::wr(reg::INCCAL_REG1));
+    c.push(cmd::wait(9));
 
     // DAC_START
-    c.push(rd(reg::TBB_REG));
-    c.push(or(12));
-    c.push(wr(reg::TBB_REG));
+    c.push(cmd::rd(reg::TBB_REG));
+    c.push(cmd::or(tbb_reg::BRF_DAC_START_LV));
+    c.push(cmd::wr(reg::TBB_REG));
 
     // EDR_PA_PU
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(or(2));
-    c.push(wr(reg::TRF_EDR_REG1));
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::or(trf_edr_reg1::BRF_TRF_EDR_PA_PU_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG1));
 
     // END
-    c.push(END);
+    c.push(cmd::END);
     c.pad_even();
     c
 }
@@ -684,149 +598,149 @@ fn build_bt_txon() -> CmdBuilder {
 fn build_bt_txoff() -> CmdBuilder {
     let mut c = CmdBuilder::new();
 
-    // EDR_PA_PU / EDR_TMXBUF_PU / EDR_TMX_PU
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(and(2));
-    c.push(and(12));
-    c.push(and(19));
-    c.push(wr(reg::TRF_EDR_REG1));
+    // EDR_PA_PU / EDR_TMXBUF_PU / EDR_TMX_PU (clear)
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::and(trf_edr_reg1::BRF_TRF_EDR_PA_PU_LV));
+    c.push(cmd::and(trf_edr_reg1::BRF_TRF_EDR_TMX_PU_LV));
+    c.push(cmd::and(trf_edr_reg1::BRF_TRF_EDR_TMXBUF_PU_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG1));
 
-    // DAC_STOP / EN_TBB_IARRY & EN_LDO_DAC_AVDD & EN_LDO_DAC_DVDD & EN_DAC
-    c.push(rd(reg::TBB_REG));
-    c.push(and(8));
-    c.push(and(9));
-    c.push(and(10));
-    c.push(and(11));
-    c.push(and(12));
-    c.push(wr(reg::TBB_REG));
+    // DAC_STOP / EN_TBB_IARRY & EN_LDO_DAC_AVDD & EN_LDO_DAC_DVDD & EN_DAC (clear)
+    c.push(cmd::rd(reg::TBB_REG));
+    c.push(cmd::and(tbb_reg::BRF_EN_TBB_IARRAY_LV));
+    c.push(cmd::and(tbb_reg::BRF_EN_LDO_DAC_DVDD_LV));
+    c.push(cmd::and(tbb_reg::BRF_EN_LDO_DAC_AVDD_LV));
+    c.push(cmd::and(tbb_reg::BRF_EN_DAC_LV));
+    c.push(cmd::and(tbb_reg::BRF_DAC_START_LV));
+    c.push(cmd::wr(reg::TBB_REG));
 
-    // EDR_PACAP_EN & EDR_PA_XFMR_SG
-    c.push(rd(reg::TRF_EDR_REG2));
-    c.push(and(11));
-    c.push(and(17));
-    c.push(wr(reg::TRF_EDR_REG2));
+    // EDR_PACAP_EN & EDR_PA_XFMR_SG (clear)
+    c.push(cmd::rd(reg::TRF_EDR_REG2));
+    c.push(cmd::and(trf_edr_reg2::BRF_TRF_EDR_PA_XFMR_SG_LV));
+    c.push(cmd::and(trf_edr_reg2::BRF_TRF_EDR_PACAP_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG2));
 
-    // cmd for cal: lpbk en
-    c.push(rd(reg::RBB_REG5));
-    c.push(and(0));
-    c.push(wr(reg::RBB_REG5));
-
-    // wait 1us
-    c.push(wait(2));
-
-    // pwrmtr_en
-    c.push(rd(reg::TRF_EDR_REG2));
-    c.push(and(10));
-    c.push(wr(reg::TRF_EDR_REG2));
+    // lpbk en (clear)
+    c.push(cmd::rd(reg::RBB_REG5));
+    c.push(cmd::and(rbb_reg5::BRF_RVGA_TX_LPBK_EN_LV));
+    c.push(cmd::wr(reg::RBB_REG5));
 
     // wait 1us
-    c.push(wait(2));
+    c.push(cmd::wait(2));
 
-    // EN_IARRAY
-    c.push(rd(reg::RBB_REG5));
-    c.push(and(5));
-    c.push(wr(reg::RBB_REG5));
+    // pwrmtr_en (clear)
+    c.push(cmd::rd(reg::TRF_EDR_REG2));
+    c.push(cmd::and(trf_edr_reg2::BRF_TRF_EDR_PWRMTR_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG2));
 
-    // EN_RVGA_I
-    c.push(rd(reg::RBB_REG2));
-    c.push(and(7));
-    c.push(wr(reg::RBB_REG2));
+    // wait 1us
+    c.push(cmd::wait(2));
 
-    // ADC & LDO_ADC & LDO_ADCREF
-    c.push(rd(reg::ADC_REG));
-    c.push(and(4));
-    c.push(and(9));
-    c.push(and(21));
-    c.push(wr(reg::ADC_REG));
+    // EN_IARRAY (clear)
+    c.push(cmd::rd(reg::RBB_REG5));
+    c.push(cmd::and(rbb_reg5::BRF_EN_IARRAY_LV));
+    c.push(cmd::wr(reg::RBB_REG5));
 
-    // TRF_EDR_IARRAY_EN
-    c.push(rd(reg::TRF_EDR_REG1));
-    c.push(and(20));
-    c.push(wr(reg::TRF_EDR_REG1));
+    // EN_RVGA_I (clear)
+    c.push(cmd::rd(reg::RBB_REG2));
+    c.push(cmd::and(rbb_reg2::BRF_EN_RVGA_I_LV));
+    c.push(cmd::wr(reg::RBB_REG2));
 
-    // EDR_EN_OSLO
-    c.push(rd(reg::OSLO_REG));
-    c.push(and(11));
-    c.push(wr(reg::OSLO_REG));
+    // ADC: LDO_ADCREF, LDO_ADC, ADC_I (clear)
+    c.push(cmd::rd(reg::ADC_REG));
+    c.push(cmd::and(adc_reg::BRF_EN_LDO_ADCREF_LV));
+    c.push(cmd::and(adc_reg::BRF_EN_LDO_ADC_LV));
+    c.push(cmd::and(adc_reg::BRF_EN_ADC_I_LV));
+    c.push(cmd::wr(reg::ADC_REG));
 
-    // VCO3G_EN/EDR_VCO_FLT_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(and(13));
-    c.push(and(7));
-    c.push(wr(reg::VCO_REG1));
+    // TRF_EDR_IARRAY_EN (clear)
+    c.push(cmd::rd(reg::TRF_EDR_REG1));
+    c.push(cmd::and(trf_edr_reg1::BRF_TRF_EDR_IARRAY_EN_LV));
+    c.push(cmd::wr(reg::TRF_EDR_REG1));
 
-    // EDR_FBDV_RSTB
-    c.push(rd(reg::FBDV_REG1));
-    c.push(or(7));
-    c.push(wr(reg::FBDV_REG1));
+    // EDR_EN_OSLO (clear)
+    c.push(cmd::rd(reg::OSLO_REG));
+    c.push(cmd::and(oslo_reg::BRF_OSLO_EN_LV));
+    c.push(cmd::wr(reg::OSLO_REG));
 
-    // EDR PFDCP_EN ICP_SET
-    c.push(rd(reg::PFDCP_REG));
-    c.push(and(19));
-    c.push(and(11));
-    c.push(or(13));
-    c.push(wr(reg::PFDCP_REG));
+    // VCO3G_EN/EDR_VCO_FLT_EN (clear)
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::and(vco_reg1::BRF_VCO3G_EN_LV));
+    c.push(cmd::and(vco_reg1::BRF_VCO_FLT_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
-    // EDR FBDV_EN/MOD_STG/SDM_CLK_SEL
-    c.push(rd(reg::FBDV_REG1));
-    c.push(and(12));
-    c.push(or(5));
-    c.push(and(4));
-    c.push(or(3));
-    c.push(wr(reg::FBDV_REG1));
+    // EDR_FBDV_RSTB (set)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_RSTB_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // ACAL_VH_SEL=3/ACAL_VL_SEL=1
-    c.push(rd(reg::VCO_REG2));
-    c.push(and(2));
-    c.push(and(6));
-    c.push(wr(reg::VCO_REG2));
+    // EDR PFDCP_EN (clear), ICP_SET (clear bit 11, set bit 13)
+    c.push(cmd::rd(reg::PFDCP_REG));
+    c.push(cmd::and(pfdcp_reg::BRF_PFDCP_EN_LV));
+    c.push(cmd::and(pfdcp_reg::BRF_PFDCP_ICP_SET_LV));      // bit 11
+    c.push(cmd::or(pfdcp_reg::BRF_PFDCP_ICP_SET_LV + 2));   // bit 13
+    c.push(cmd::wr(reg::PFDCP_REG));
 
-    // LDO_RBB
-    c.push(rd(reg::RBB_REG1));
-    c.push(and(13));
-    c.push(wr(reg::RBB_REG1));
+    // EDR FBDV_EN(clear)/MOD_STG(restore 5G: MOD_STG=2, SDM_CLK_SEL=1)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_EN_LV));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_MOD_STG_LV + 1));  // bit 5
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_MOD_STG_LV));      // bit 4
+    c.push(cmd::or(fbdv_reg1::BRF_SDM_CLK_SEL_LV));        // bit 3
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // EDR VCO3G_EN/EDR_VCO5G_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(and(13));
-    c.push(wr(reg::EDR_CAL_REG1));
+    // ACAL_VH_SEL=3/ACAL_VL_SEL=1 (clear bit 2, clear bit 6)
+    c.push(cmd::rd(reg::VCO_REG2));
+    c.push(cmd::and(vco_reg2::BRF_VCO_ACAL_VL_SEL_LV + 2)); // bit 2
+    c.push(cmd::and(vco_reg2::BRF_VCO_ACAL_VH_SEL_LV + 2)); // bit 6
+    c.push(cmd::wr(reg::VCO_REG2));
 
-    // VDDPSW/RFBG_EN/LO_IARY_EN/LODISTEDR_EN
-    c.push(rd(reg::RF_LODIST_REG));
-    c.push(and(0));
-    c.push(and(16));
-    c.push(and(17));
-    c.push(and(18));
-    c.push(wr(reg::RF_LODIST_REG));
+    // LDO_RBB (clear)
+    c.push(cmd::rd(reg::RBB_REG1));
+    c.push(cmd::and(rbb_reg1::BRF_EN_LDO_RBB_LV));
+    c.push(cmd::wr(reg::RBB_REG1));
+
+    // EDR VCO3G_EN (clear) → write to EDR_CAL_REG1
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::and(vco_reg1::BRF_VCO3G_EN_LV));
+    c.push(cmd::wr(reg::EDR_CAL_REG1));
+
+    // VDDPSW/RFBG_EN/LO_IARY_EN/LODISTEDR_EN (clear)
+    c.push(cmd::rd(reg::RF_LODIST_REG));
+    c.push(cmd::and(rf_lodist_reg::BRF_LODISTEDR_EN_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_LO_IARY_EN_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_EN_RFBG_LV));
+    c.push(cmd::and(rf_lodist_reg::BRF_EN_VDDPSW_LV));
+    c.push(cmd::wr(reg::RF_LODIST_REG));
 
     // Redundant commands to fix control change while txoff:
-    // VCO5G_EN & VCO_FLT_EN
-    c.push(rd(reg::VCO_REG1));
-    c.push(and(12));
-    c.push(and(7));
-    c.push(wr(reg::VCO_REG1));
+    // VCO5G_EN & VCO_FLT_EN (clear)
+    c.push(cmd::rd(reg::VCO_REG1));
+    c.push(cmd::and(vco_reg1::BRF_VCO5G_EN_LV));
+    c.push(cmd::and(vco_reg1::BRF_VCO_FLT_EN_LV));
+    c.push(cmd::wr(reg::VCO_REG1));
 
-    // FBDV_EN / FBDV_RSTB
-    c.push(rd(reg::FBDV_REG1));
-    c.push(and(12));
-    c.push(or(0x7));
-    c.push(wr(reg::FBDV_REG1));
+    // FBDV_EN (clear) / FBDV_RSTB (set)
+    c.push(cmd::rd(reg::FBDV_REG1));
+    c.push(cmd::and(fbdv_reg1::BRF_FBDV_EN_LV));
+    c.push(cmd::or(fbdv_reg1::BRF_FBDV_RSTB_LV));
+    c.push(cmd::wr(reg::FBDV_REG1));
 
-    // PFDCP_EN
-    c.push(rd(reg::PFDCP_REG));
-    c.push(and(19));
-    c.push(wr(reg::PFDCP_REG));
+    // PFDCP_EN (clear)
+    c.push(cmd::rd(reg::PFDCP_REG));
+    c.push(cmd::and(pfdcp_reg::BRF_PFDCP_EN_LV));
+    c.push(cmd::wr(reg::PFDCP_REG));
 
-    // PA_BUF_PU & PA_OUT_PU & TRF_SIG_EN
-    c.push(rd(reg::TRF_REG1));
-    c.push(and(22));
-    c.push(and(16));
-    c.push(and(21));
-    c.push(wr(reg::TRF_REG1));
+    // PA_BUF_PU & PA_OUT_PU & TRF_SIG_EN (clear)
+    c.push(cmd::rd(reg::TRF_REG1));
+    c.push(cmd::and(trf_reg1::BRF_PA_BUF_PU_LV));
+    c.push(cmd::and(trf_reg1::BRF_TRF_SIG_EN_LV));
+    c.push(cmd::and(trf_reg1::BRF_PA_OUT_PU_LV));
+    c.push(cmd::wr(reg::TRF_REG1));
 
     // END
-    c.push(END);
+    c.push(cmd::END);
     c.pad_even();
     c
 }
@@ -865,6 +779,8 @@ fn init_inccal_timing() {
 ///
 /// Returns the next free SRAM offset after all sequences.
 pub fn generate_rfc_cmd_sequences() -> u32 {
+    let base = super::BT_RFC_MEM_BASE;
+
     // Initialize INCCAL timing
     init_inccal_timing();
 
@@ -877,7 +793,7 @@ pub fn generate_rfc_cmd_sequences() -> u32 {
     BT_RFC.cu_addr_reg1().write(|w| {
         w.set_rxon_cfg_addr(rxon_addr as u16);
     });
-    addr = rxon.write_to_sram(rxon_addr);
+    addr = unsafe { rxon.write_to_sram(base, rxon_addr) };
 
     // === RXOFF ===
     let rxoff = build_rxoff();
@@ -885,7 +801,7 @@ pub fn generate_rfc_cmd_sequences() -> u32 {
     BT_RFC.cu_addr_reg1().modify(|w| {
         w.set_rxoff_cfg_addr(rxoff_addr as u16);
     });
-    addr = rxoff.write_to_sram(rxoff_addr);
+    addr = unsafe { rxoff.write_to_sram(base, rxoff_addr) };
 
     // === TXON ===
     let txon = build_txon();
@@ -893,7 +809,7 @@ pub fn generate_rfc_cmd_sequences() -> u32 {
     BT_RFC.cu_addr_reg2().write(|w| {
         w.set_txon_cfg_addr(txon_addr as u16);
     });
-    addr = txon.write_to_sram(txon_addr);
+    addr = unsafe { txon.write_to_sram(base, txon_addr) };
 
     // === TXOFF ===
     let txoff = build_txoff();
@@ -901,7 +817,7 @@ pub fn generate_rfc_cmd_sequences() -> u32 {
     BT_RFC.cu_addr_reg2().modify(|w| {
         w.set_txoff_cfg_addr(txoff_addr as u16);
     });
-    addr = txoff.write_to_sram(txoff_addr);
+    addr = unsafe { txoff.write_to_sram(base, txoff_addr) };
 
     // === BT_TXON ===
     let bt_txon = build_bt_txon();
@@ -909,7 +825,7 @@ pub fn generate_rfc_cmd_sequences() -> u32 {
     BT_RFC.cu_addr_reg3().write(|w| {
         w.set_bt_txon_cfg_addr(bt_txon_addr as u16);
     });
-    addr = bt_txon.write_to_sram(bt_txon_addr);
+    addr = unsafe { bt_txon.write_to_sram(base, bt_txon_addr) };
 
     // === BT_TXOFF ===
     let bt_txoff = build_bt_txoff();
@@ -917,7 +833,7 @@ pub fn generate_rfc_cmd_sequences() -> u32 {
     BT_RFC.cu_addr_reg3().modify(|w| {
         w.set_bt_txoff_cfg_addr(bt_txoff_addr as u16);
     });
-    addr = bt_txoff.write_to_sram(bt_txoff_addr);
+    addr = unsafe { bt_txoff.write_to_sram(base, bt_txoff_addr) };
 
     addr
 }


### PR DESCRIPTION
## Summary

- Add `rwbt` crate dependency for RFC command sequencer and register definitions
- Extract shared calibration constants (IDAC/PDX params, VCO thresholds, FCW values, FBDV mode) into new `consts.rs` module
- Replace hardware config magic numbers with named constants across all bt_rf_cal files (vco, edr_lo, txdc, txdc_hw, rfc_tables, mod)
- Refactor `rfc_cmd.rs` to use `rwbt::rfc` register offsets and bit positions instead of raw hex literals
- Remove conservatively added delays not present in SDK
- Deduplicate `DEFAULT_EDR_PA_BM` between txdc.rs and mod.rs

## Test plan

- [x] `cargo build --release --bins` passes
- [x] `cargo clippy --release --bins` passes with zero bt_rf_cal warnings
- [x] On-device BT RF calibration functional test

🤖 Generated with [Claude Code](https://claude.com/claude-code)